### PR TITLE
Adding equals and hashcode for identical variant check

### DIFF
--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -32,11 +32,6 @@
       <artifactId>commons-cli</artifactId>
       <version>1.3</version>
     </dependency>
-    <dependency>
-      <groupId>org.cbio</groupId>
-      <artifactId>gdcpipeline</artifactId>
-      <version>0.0.1-SNAPSHOT</version>
-    </dependency>
   </dependencies>
 </project>
   

--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>commons-cli</artifactId>
       <version>1.3</version>
     </dependency>
+    <dependency>
+      <groupId>org.cbio</groupId>
+      <artifactId>gdcpipeline</artifactId>
+      <version>0.0.1-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 </project>
   

--- a/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
@@ -79,6 +79,8 @@ public class MutationRecord {
     protected String nAltCount;
     protected Map<String, String> additionalProperties = new LinkedHashMap<>();
     protected List<String> header = new ArrayList<>();
+    public static List<String> missingValueList = initMissingValueList();
+
 
     public MutationRecord() {
         initHeader();
@@ -506,5 +508,62 @@ public class MutationRecord {
         header.add("t_alt_count");
         header.add("n_ref_count");
         header.add("n_alt_count");
+    }
+
+    private static List<String> initMissingValueList() {
+        List<String> missingValueList = new ArrayList<>();
+        missingValueList.add("NA");
+        missingValueList.add("N/A");
+        missingValueList.add("N/a");
+        missingValueList.add("n/A");
+        missingValueList.add("Unknown");
+        missingValueList.add("not available");
+        return missingValueList;
+    }
+
+    public static boolean hasMissingKeys(String check) {
+        for (String ignore : missingValueList) {
+            if (check.equalsIgnoreCase(ignore)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        MutationRecord record = (MutationRecord) o;
+
+        if (!getCHROMOSOME().equals(record.getCHROMOSOME())) return false;
+        if (!startPosition.equals(record.startPosition)) return false;
+        if (!endPosition.equals(record.endPosition)) return false;
+        if (!getSTRAND().equals(record.getSTRAND())) return false;
+        if (!referenceAllele.equals(record.referenceAllele)) return false;
+        if (!tumorSampleBarcode.equals(record.tumorSampleBarcode)) return false;
+        return sameTumourSequence(record);
+    }
+
+    private boolean sameTumourSequence(MutationRecord record) {
+        if (!(getTUMOR_SEQ_ALLELE1().equals(getREFERENCE_ALLELE()) || getTUMOR_SEQ_ALLELE1().isEmpty() || hasMissingKeys(getTUMOR_SEQ_ALLELE1()))) {
+            return getTUMOR_SEQ_ALLELE1().equals(getTUMOR_SEQ_ALLELE1());
+        }
+        return getTUMOR_SEQ_ALLELE2().equals(record.getTUMOR_SEQ_ALLELE2());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getCHROMOSOME().hashCode();
+        result = 31 * result + startPosition.hashCode();
+        result = 31 * result + endPosition.hashCode();
+        result = 31 * result + getSTRAND().hashCode();
+        result = 31 * result + referenceAllele.hashCode();
+        result = 31 * result + (tumorSeqAllele1 != null ? tumorSeqAllele1.hashCode() : 0);
+        result = 31 * result + tumorSeqAllele2.hashCode();
+        result = 31 * result + tumorSampleBarcode.hashCode();
+        return result;
     }
 }

--- a/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
@@ -79,8 +79,6 @@ public class MutationRecord {
     protected String nAltCount;
     protected Map<String, String> additionalProperties = new LinkedHashMap<>();
     protected List<String> header = new ArrayList<>();
-    public static List<String> missingValueList = initMissingValueList();
-
 
     public MutationRecord() {
         initHeader();
@@ -510,26 +508,35 @@ public class MutationRecord {
         header.add("n_alt_count");
     }
 
-    private static List<String> initMissingValueList() {
-        List<String> missingValueList = new ArrayList<>();
-        missingValueList.add("NA");
-        missingValueList.add("N/A");
-        missingValueList.add("N/a");
-        missingValueList.add("n/A");
-        missingValueList.add("Unknown");
-        missingValueList.add("not available");
-        return missingValueList;
-    }
+    public static enum MissingAttributeValues
+    {
+        NOT_APPLICABLE("Not Applicable"),
+        NOT_AVAILABLE("Not Available"),
+        PENDING("Pending"),
+        DISCREPANCY("Discrepancy"),
+        COMPLETED("Completed"),
+        NULL("null"),
+        MISSING(""),
+        NA("NA");
 
-    public static boolean hasMissingKeys(String check) {
-        for (String ignore : missingValueList) {
-            if (check.equalsIgnoreCase(ignore)) {
-                return true;
+        private String propertyName;
+
+        MissingAttributeValues(String propertyName) { this.propertyName = propertyName; }
+        public String toString() { return propertyName; }
+
+        static public boolean has(String value) {
+            if (value == null) return false;
+            if (value.trim().equals("")) return true;
+            try {
+                value = value.replaceAll("[\\[|\\]]", "");
+                value = value.replaceAll(" ", "_");
+                return valueOf(value.toUpperCase()) != null;
+            }
+            catch (IllegalArgumentException x) {
+                return false;
             }
         }
-        return false;
     }
-
 
     @Override
     public boolean equals(Object o) {
@@ -548,7 +555,7 @@ public class MutationRecord {
     }
 
     private boolean sameTumourSequence(MutationRecord record) {
-        if (!(getTUMOR_SEQ_ALLELE1().equals(getREFERENCE_ALLELE()) || getTUMOR_SEQ_ALLELE1().isEmpty() || hasMissingKeys(getTUMOR_SEQ_ALLELE1()))) {
+        if (!(getTUMOR_SEQ_ALLELE1().equals(getREFERENCE_ALLELE()) || getTUMOR_SEQ_ALLELE1().isEmpty() || MissingAttributeValues.has(getTUMOR_SEQ_ALLELE1()))) {
             return getTUMOR_SEQ_ALLELE1().equals(getTUMOR_SEQ_ALLELE1());
         }
         return getTUMOR_SEQ_ALLELE2().equals(record.getTUMOR_SEQ_ALLELE2());
@@ -559,7 +566,7 @@ public class MutationRecord {
         int result = getCHROMOSOME().hashCode();
         result = 31 * result + startPosition.hashCode();
         result = 31 * result + endPosition.hashCode();
-        result = 31 * result + getSTRAND().hashCode();
+        result = 31 * result + strand.hashCode();
         result = 31 * result + referenceAllele.hashCode();
         result = 31 * result + (tumorSeqAllele1 != null ? tumorSeqAllele1.hashCode() : 0);
         result = 31 * result + tumorSeqAllele2.hashCode();


### PR DESCRIPTION
This change implements equals and hashcode method to compare two mutation records and check if they are identical variants or not. 