### PR TITLE
Updated database annotator pipeline

### DIFF
--- a/databaseAnnotator/pom.xml
+++ b/databaseAnnotator/pom.xml
@@ -91,14 +91,7 @@
             <groupId>com.querydsl</groupId>
             <artifactId>querydsl-jpa</artifactId>
             <version>4.1.2</version>
-        </dependency>     
-
-        <!-- for Oracle usage -->
-        <dependency>
-            <groupId>com.oracle</groupId>
-            <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>

--- a/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
+++ b/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
@@ -80,8 +80,8 @@ public class AnnotateRecordsProcessor implements ItemProcessor<MutationEvent, Mu
             chromosome = i.getCHR();
         }
         mafLine.put("Chromosome", chromosome);
-        mafLine.put("START_POSITION", String.valueOf(i.getSTART_POSITION()));
-        mafLine.put("END_POSITION", String.valueOf(i.getEND_POSITION()));
+        mafLine.put("Start_Position", String.valueOf(i.getSTART_POSITION()));
+        mafLine.put("End_Position", String.valueOf(i.getEND_POSITION()));
         mafLine.put("Reference_Allele", i.getREFERENCE_ALLELE());
         mafLine.put("Tumor_Seq_Allele2", i.getTUMOR_SEQ_ALLELE());
         MutationRecord record = annotator.createRecord(mafLine);

--- a/databaseAnnotator/src/main/resources/application.properties.EXAMPLE
+++ b/databaseAnnotator/src/main/resources/application.properties.EXAMPLE
@@ -5,6 +5,7 @@ databaseannotator.pass=
 databaseannotator.driver=com.mysql.jdbc.Driver
 databaseannotator.connection_string=jdbc:mysql://<HOST>/<DATABASE>
 
-genomenexus.hgvs=http://<HOST>:<PORT>/variant_annotation/hgvs/
+genomenexus.hgvs=<HOST>/variant_annotation/hgvs/
+genomenexus.xrefs=<HOST>/xrefs/
 genomenexus.isoform_query_parameter=isoformOverrideSource
-genomenexus.hotspot_parameter=cancerHotspots
+genomenexus.enrichment_fields=hotspots,mutation_assessor


### PR DESCRIPTION
* Removed unused oracle dependency from pom.
* Fixed casing issue in the processor that prevented the start and end genomic coordinates from being set properly when being converted to an`AnnotatedRecord` object.
* Updated example `application.properties`

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>