### PR TITLE
Fixed how HGVSp is resolved from HGVSc.

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -369,7 +369,7 @@ public class GenomeNexusImpl implements Annotator {
                 if (m.matches()) {
                     cPos = Integer.parseInt(m.group(1));
                     cPos = cPos < 1 ? 1 : cPos;
-                    pPos = (cPos + cPos % 3) / 3;
+                    pPos = (int)Math.ceil(((cPos + cPos % 3) / 3.0));
                     hgvsp = "p.X" + String.valueOf(pPos) + "_splice";
                 }
             }


### PR DESCRIPTION
When resolving HGVSp from HGVSc, the protein coordinate resolved was not always correct.

Example:
HGVSc: `ENST00000397752.3:c.3028+2T>C`
Protein change returned: `p.X1009_splice`
Protein change expected: `p.X1010_splice`

We should be rounding up the value of the resolved protein coordinate.

Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>