### PR TITLE
Bug fix for IF indels miscategorized as FS indels.

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -719,10 +719,12 @@ public class GenomeNexusImpl implements Annotator {
     }
 
     private String getVariantClassificationFromMap(String variant) {
-        boolean inframe = Math.abs(mRecord.getREFERENCE_ALLELE().length() - getTumorSeqAllele(mRecord).length()) % 3 == 0;
+        String refAllele = mRecord.getREFERENCE_ALLELE().equals("-") ? "" : mRecord.getREFERENCE_ALLELE();
+        String tumorSeqAllele = getTumorSeqAllele(mRecord).equals("-") ? "" : getTumorSeqAllele(mRecord);
+        boolean inframe = Math.abs(refAllele.length() - tumorSeqAllele.length()) % 3 == 0;
         variant = variant.toLowerCase();
         String resolvedVariantType = resolveVariantType();
-        if ((variant.equals("frameshift_variant") || (variant.equals("protein_altering_variant") || variant.equals("coding_sequence_variant")) && !inframe)) {
+        if ((variant.equals("frameshift_variant") || variant.equals("protein_altering_variant") || variant.equals("coding_sequence_variant")) && !inframe) {
             if (resolvedVariantType.equals("DEL")) {
                 return "Frame_Shift_Del";
             }


### PR DESCRIPTION
A parenthesis was misplaced when handling frame shift events, which helped miscategorize In Frame indels as Frame Shift indels. 

The way that a variant is determined to be in frame or not was also modified to ensure that we correctly identify in frame events.


Signed-off-by: Angelica Ochoa <aochoa4230@gmail.com>