### PR TITLE
Test vcf2maf test.maf file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,3 +47,7 @@ jobs:
       - run:
           name: "check if maf file still the same when annotating with mskcc transcripts"
           command: 'java -jar annotationPipeline/target/annotationPipeline-0.1.0.jar --filename test/data/data_mutations_extended_100.in.txt  --output-filename test/data/data_mutations_extended_100.out.mskcc.txt --isoform-override mskcc && git diff --exit-code test/data/data_mutations_extended_100.out.mskcc.txt || (echo -e "MAF mskcc output changed test/data/data_mutations_extended_100.out.mskcc.txt $(cat test/data/data_mutations_extended_100.out.mskcc.txt | curl -F c=@- https://ptpb.pw | grep url) (include this file in your PR to fix this test)" && exit 1)'
+
+      - run:
+          name: "Run vcf2maf test cases"
+          command: 'sudo apt-get install make && ./test/scripts/vcf2maf_tests.sh'

--- a/test/data/vcf2maf/Makefile
+++ b/test/data/vcf2maf/Makefile
@@ -1,0 +1,28 @@
+SHELL=/bin/bash
+VCF2MAF_VERSION=1ce59edc767e5761681a9367ee76c861b7160883
+VCF2MAF_URL=https://raw.githubusercontent.com/mskcc/vcf2maf/$(VCF2MAF_VERSION)
+ALL=tests.maf test_output.mskcc.maf test_output.uniprot.maf test_output.mskcc.cut_columns.txt test_output.uniprot.cut_columns.txt
+
+COMPARE_COLUMNS=Hugo_Symbol Chromosome Start_Position End_Position Strand Variant_Classification Variant_Type Reference_Allele Tumor_Seq_Allele1 Tumor_Seq_Allele2 Tumor_Sample_Barcode Matched_Norm_Sample_Barcode Match_Norm_Seq_Allele1 Match_Norm_Seq_Allele2 Tumor_Validation_Allele1 Tumor_Validation_Allele2 Match_Norm_Validation_Allele1 Match_Norm_Validation_Allele2 Verification_Status Validation_Status Mutation_Status Sequencing_Phase Sequence_Source Validation_Method Score BAM_File Sequencer t_ref_count t_alt_count n_ref_count n_alt_count n_depth t_depth
+
+tests.maf:
+	curl $(VCF2MAF_URL)/tests/test.maf > $@
+
+test_output.mskcc.maf:
+	curl $(VCF2MAF_URL)/tests/test_output.custom_isoforms.maf > $@
+
+test_output.uniprot.maf:
+	curl $(VCF2MAF_URL)/tests/test_output.vep_isoforms.maf > $@
+
+%.cut_columns.txt: %.maf
+	if [[ "$(uname)" = "Darwin" ]]; then \
+		AWK=gawk; \
+	else \
+		AWK=awk; \
+	fi; \
+	(echo $(COMPARE_COLUMNS) | sed 's/\ /	/g'; tail -n+2 $< | $$AWK -vOFS='\t' -vFS='\t' -f ./../../scripts/select_by_column_name.awk $(COMPARE_COLUMNS)) > $@
+
+all: $(ALL)
+
+clean:
+	rm -rf $(ALL)

--- a/test/data/vcf2maf/README.md
+++ b/test/data/vcf2maf/README.md
@@ -1,0 +1,1 @@
+Update by running `make clean && make all`. Used by `../../scripts/vcf2maf_tests.sh`

--- a/test/scripts/select_by_column_name.awk
+++ b/test/scripts/select_by_column_name.awk
@@ -1,0 +1,40 @@
+#!/usr/bin/awk -f
+# Process standard input outputting named columns provided as arguments.
+#
+# For example, given foo.dat containing
+#     a b c c
+#     1a 1b 1c 1C
+#     2a 2b 2c 2C
+#     3a 3b 3c 3C
+# Running
+#   cat foo.dat | ./namedcols c b a a d
+# will output
+#   1c 1b 1a 1a d
+#   2c 2b 2a 2a d
+#   3c 3b 3a 3a d
+# and will warn on standard error that it
+#   Ignored duplicate 'c' in column 4
+# Notice that the requested but missing column d contains "d".
+#
+# Using awk's -F feature it is possible to parse comma-separated data:
+#   cat foo.csv | ./namedcols -F, c b a a d
+BEGIN {
+    for (i=1; i<ARGC; ++i)
+        desired[i] = ARGV[i]
+    delete ARGV
+}
+NR==1 {
+    for (i=1; i<=NF; i++)
+        if ($i in names)
+            printf "Ignored duplicate '%s' in column %d\n", $i, i | "cat 1>&2"
+        else
+            names[$i] = i
+    next
+}
+{
+    for (i=1; i<ARGC; ++i)
+        printf "%s%s",                                          \
+               (i==1 ? "" : OFS),                               \
+               ((ndx = names[name = desired[i]])>0 ? $ndx: name)
+    printf RS
+}

--- a/test/scripts/vcf2maf_tests.sh
+++ b/test/scripts/vcf2maf_tests.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Test vcf2maf test data for maf
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+set -e
+
+exit_code=0
+
+cd $DIR/../data/vcf2maf/ && make clean && make all
+cd $DIR
+
+for isoform in mskcc uniprot
+do
+    java -jar $DIR/../../annotationPipeline/target/annotationPipeline-0.1.0.jar --filename $DIR/../data/vcf2maf/tests.maf  --output-filename $DIR/../data/vcf2maf/tests.maf.gn_output.${isoform}.maf --isoform-override ${isoform} && \
+        cd $DIR/../data/vcf2maf/ && \
+        make tests.maf.gn_output.${isoform}.cut_columns.txt && \
+        diff tests.maf.gn_output.${isoform}.cut_columns.txt test_output.${isoform}.cut_columns.txt || exit_code=1;
+done
+
+exit $exit_code


### PR DESCRIPTION
Create a test that uses vcf2maf test.maf file and checks whether the output of
genome nexus is the same as that from vcf2maf.

Only compares the columns 
```
$ csvcut -tn test/data/vcf2maf/tests.maf.gn_output.uniprot.cut_columns.txt
  1: Hugo_Symbol
  2: Chromosome
  3: Start_Position
  4: End_Position
  5: Strand
  6: Variant_Classification
  7: Variant_Type
  8: Reference_Allele
  9: Tumor_Seq_Allele1
 10: Tumor_Seq_Allele2
 11: Tumor_Sample_Barcode
 12: Matched_Norm_Sample_Barcode
 13: Match_Norm_Seq_Allele1
 14: Match_Norm_Seq_Allele2
 15: Tumor_Validation_Allele1
 16: Tumor_Validation_Allele2
 17: Match_Norm_Validation_Allele1
 18: Match_Norm_Validation_Allele2
 19: Verification_Status
 20: Validation_Status
 21: Mutation_Status
 22: Sequencing_Phase
 23: Sequence_Source
 24: Validation_Method
 25: Score
 26: BAM_File
 27: Sequencer
 28: t_ref_count
 29: t_alt_count
 30: n_ref_count
 31: n_alt_count
 32: n_depth
 33: t_depth
```