### PR TITLE
Change hash to use updated cbioportal code (SSL args)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>com.github.cbioportal</groupId>
       <artifactId>cbioportal</artifactId>
-      <version>22de17599f7fe894b209930f89403ed46b081b1d</version>
+      <version>62ccd522ab30a578690f67cf754e9d2ccf23043a</version>
     </dependency>
     <!-- api client -->
     <dependency>


### PR DESCRIPTION
update cbioportal jitpack dependency
prevents conflicts when building importer (clashing cbioportal jars)
Hash is the current head of master (merge of SSL PR:  https://github.com/cBioPortal/cbioportal/pull/5734 )