### PR TITLE
Add customized columns to annotation file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,13 @@ annotationPipeline/src/main/resources/log4j.properties
 databaseAnnotator/src/main/resources/log4j.properties
 *.iml
 swagger-codegen-cli.jar
+.idea/l*
+*.prefs
+*.class
+*.EXAMPLE
+*.properties
+*.jar
+*.project
+*.lst
+.idea/*
+*.classpath

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -57,7 +57,9 @@ public class AnnotationPipeline
             .addOption("i", "isoform-override", true, "Isoform Overrides (mskcc or uniprot)")
             .addOption("e", "error-report-location", true, "Error report filename (including path)")
             .addOption("r", "replace-symbol-entrez", false, "Replace gene symbols and entrez id with what is provided by annotator" )
-            .addOption("v", "verbose", false, "Verbose mode will log all annotation failures");
+            .addOption("v", "verbose", false, "Verbose mode will log all annotation failures")
+            .addOption("ac", "add-columns", true, "Customize what columns will be in the output file")
+            .addOption("p", "prefix", true, "Customize the prefix of column name");
 
         return gnuOptions;
     }
@@ -69,7 +71,7 @@ public class AnnotationPipeline
         System.exit(exitStatus);
     }
 
-    private static void launchJob(String[] args, String filename, String outputFilename, String isoformOverride, String errorReportLocation, boolean replace, boolean verbose) throws Exception
+    private static void launchJob(String[] args, String filename, String outputFilename, String isoformOverride, String errorReportLocation, boolean replace, boolean verbose, String addColumns, String prefix) throws Exception
     {
         SpringApplication app = new SpringApplication(AnnotationPipeline.class);
         ConfigurableApplicationContext ctx = app.run(args);
@@ -83,6 +85,8 @@ public class AnnotationPipeline
             .addString("isoformOverride", isoformOverride)
             .addString("errorReportLocation", errorReportLocation)
             .addString("verbose", String.valueOf(verbose))
+            .addString("addColumns", addColumns)
+            .addString("prefix", prefix)
             .toJobParameters();
         JobExecution jobExecution = jobLauncher.run(annotationJob, jobParameters);
         if (!jobExecution.getExitStatus().equals(ExitStatus.COMPLETED)) {
@@ -100,6 +104,13 @@ public class AnnotationPipeline
             !commandLine.hasOption("output-filename")) {
             help(gnuOptions, 0);
         }
-        launchJob(args, commandLine.getOptionValue("filename"), commandLine.getOptionValue("output-filename"), commandLine.getOptionValue("isoform-override"), commandLine.hasOption("error-report-location") ? commandLine.getOptionValue("error-report-location") : null, commandLine.hasOption("replace-symbol-entrez"), commandLine.hasOption("verbose"));
+        launchJob(args, commandLine.getOptionValue("filename"), 
+        commandLine.getOptionValue("output-filename"), 
+        commandLine.getOptionValue("isoform-override"), 
+        commandLine.hasOption("error-report-location") ? commandLine.getOptionValue("error-report-location") : null, 
+        commandLine.hasOption("replace-symbol-entrez"), 
+        commandLine.hasOption("verbose"), 
+        commandLine.hasOption("add-columns") ? commandLine.getOptionValue("add-columns") : null, 
+        commandLine.hasOption("prefix") ? commandLine.getOptionValue("prefix") : null);
     }
 }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationFieldSetMapper.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationFieldSetMapper.java
@@ -57,7 +57,7 @@ public class MutationFieldSetMapper implements  FieldSetMapper<MutationRecord> {
             }
             catch (Exception e) {
                 if (e.getClass().equals(NoSuchMethodException.class)) {
-                    record.addAdditionalProperty(field, fs.readRawString(field));
+                    record.addAdditionalProperty(field, fs.readRawString(field), "");
                 }
                 else {
                     LOG.error("Something went wrong reading field " + field);

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -74,6 +74,9 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
     @Value("#{jobParameters['addColumns']}")
     private String addColumns;
 
+    @Value("#{jobParameters['prefix']}")
+    private String prefix;
+
     private int failedAnnotations;
     private int failedServerAnnotations;
     private int failedNullHgvspAnnotations;
@@ -143,7 +146,7 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
             String serverErrorMessage = "";
             AnnotatedRecord annotatedRecord = new AnnotatedRecord(record);
             try {
-                annotatedRecord = annotator.annotateRecord(record, replace, isoformOverride, true, addColumns);
+                annotatedRecord = annotator.annotateRecord(record, replace, isoformOverride, true, addColumns, prefix);
             }
             catch (HttpServerErrorException ex) {
                 serverErrorMessage = "Failed to annotate variant due to internal server error";
@@ -158,7 +161,7 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
                 serverErrorMessage = "Failed to annotate variant due to Genome Nexus : " + ex.getMessage();
             }
             annotatedRecords.add(annotatedRecord);
-            header.addAll(annotatedRecord.getHeaderWithAdditionalFields());
+            header.addAll(annotatedRecord.getHeaderWithAdditionalFields(prefix));
             
             // log server failure message if applicable
             if (!serverErrorMessage.isEmpty()) {

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -71,6 +71,9 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
     @Value("#{jobParameters[verbose]}")
     private boolean verbose;
 
+    @Value("#{jobParameters['addColumns']}")
+    private String addColumns;
+
     private int failedAnnotations;
     private int failedServerAnnotations;
     private int failedNullHgvspAnnotations;
@@ -140,7 +143,7 @@ public class MutationRecordReader  implements ItemStreamReader<AnnotatedRecord>{
             String serverErrorMessage = "";
             AnnotatedRecord annotatedRecord = new AnnotatedRecord(record);
             try {
-                annotatedRecord = annotator.annotateRecord(record, replace, isoformOverride, true);
+                annotatedRecord = annotator.annotateRecord(record, replace, isoformOverride, true, addColumns);
             }
             catch (HttpServerErrorException ex) {
                 serverErrorMessage = "Failed to annotate variant due to internal server error";

--- a/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
@@ -44,7 +44,7 @@ import org.cbioportal.models.MutationRecord;
 
 public interface Annotator {
 
-    AnnotatedRecord annotateRecord(MutationRecord record, boolean replaceHugo, String isoformOverride, boolean reannotate) throws GenomeNexusAnnotationFailureException;
+    AnnotatedRecord annotateRecord(MutationRecord record, boolean replaceHugo, String isoformOverride, boolean reannotate, String addColumns) throws GenomeNexusAnnotationFailureException;
     MutationRecord createRecord(Map<String, String> mafLine) throws Exception;
     boolean isHgvspNullClassifications(String variantClassification);
     String getUrlForRecord(MutationRecord record, String isoformOverridesSource);

--- a/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
@@ -44,7 +44,7 @@ import org.cbioportal.models.MutationRecord;
 
 public interface Annotator {
 
-    AnnotatedRecord annotateRecord(MutationRecord record, boolean replaceHugo, String isoformOverride, boolean reannotate, String addColumns) throws GenomeNexusAnnotationFailureException;
+    AnnotatedRecord annotateRecord(MutationRecord record, boolean replaceHugo, String isoformOverride, boolean reannotate, String addColumns, String prefix) throws GenomeNexusAnnotationFailureException;
     MutationRecord createRecord(Map<String, String> mafLine) throws Exception;
     boolean isHgvspNullClassifications(String variantClassification);
     String getUrlForRecord(MutationRecord record, String isoformOverridesSource);

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -123,6 +123,11 @@ public class GenomeNexusImpl implements Annotator {
     {
         this.mRecord = record;
 
+        String[] names = optionalGnProperties.split(",");
+        for (String name : names) {
+            this.mRecord.addAdditionalProperty(name, name);
+        }
+
         //check if record already is annotated
         if(!reannotate && !annotationNeeded(record)) {
             return new AnnotatedRecord(mRecord);

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -119,7 +119,7 @@ public class GenomeNexusImpl implements Annotator {
     }
 
     @Override
-    public AnnotatedRecord annotateRecord(MutationRecord record, boolean replace, String isoformOverridesSource, boolean reannotate, String optionalGnProperties)
+    public AnnotatedRecord annotateRecord(MutationRecord record, boolean replace, String isoformOverridesSource, boolean reannotate, String optionalGnProperties, String prefix)
             throws GenomeNexusAnnotationFailureException
     {
         this.mRecord = record;  
@@ -141,11 +141,11 @@ public class GenomeNexusImpl implements Annotator {
         if (optionalGnProperties.contains(",")) {
             String[] names = optionalGnProperties.split(",");
             for (String name : names) {
-                this.mRecord.addAdditionalProperty(name, resolveAdditionalHeader(name));
+                this.mRecord.addAdditionalProperty(name, resolveAdditionalHeader(name), prefix);
             }
         }
         else {
-            this.mRecord.addAdditionalProperty(optionalGnProperties, resolveAdditionalHeader(optionalGnProperties));
+            this.mRecord.addAdditionalProperty(optionalGnProperties, resolveAdditionalHeader(optionalGnProperties), prefix);
         }
 
         return convertResponseToAnnotatedRecord(replace);

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -118,7 +118,7 @@ public class GenomeNexusImpl implements Annotator {
     }
 
     @Override
-    public AnnotatedRecord annotateRecord(MutationRecord record, boolean replace, String isoformOverridesSource, boolean reannotate)
+    public AnnotatedRecord annotateRecord(MutationRecord record, boolean replace, String isoformOverridesSource, boolean reannotate, String optionalGnProperties)
             throws GenomeNexusAnnotationFailureException
     {
         this.mRecord = record;

--- a/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/MutationRecord.java
@@ -441,8 +441,8 @@ public class MutationRecord {
         this.nAltCount = nAltCount;
     }
 
-    public void addAdditionalProperty(String property, String value) {
-        this.additionalProperties.put(property, value);
+    public void addAdditionalProperty(String property, String value, String prefix) {
+        this.additionalProperties.put(prefix + "." + property, value);
     }
 
     public Map<String, String> getAdditionalProperties() {
@@ -453,7 +453,7 @@ public class MutationRecord {
         this.additionalProperties = additionalProperties;
     }
 
-    public List<String> getHeaderWithAdditionalFields() {
+    public List<String> getHeaderWithAdditionalFields(String prefix) {
         List<String> headerWithAdditionalFields = new ArrayList<>();
         headerWithAdditionalFields.addAll(header);
 

--- a/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
+++ b/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
@@ -56,6 +56,9 @@ public class AnnotateRecordsProcessor implements ItemProcessor<MutationEvent, Mu
     @Value("#{jobParameters[isoform]}")
     private String isoform;
 
+    @Value("#{jobParameters['addColumns']}")
+    private String addColumns;
+
     @Autowired
     Annotator annotator;
 
@@ -88,7 +91,7 @@ public class AnnotateRecordsProcessor implements ItemProcessor<MutationEvent, Mu
         MutationRecord record = annotator.createRecord(mafLine);
         AnnotatedRecord annotatedRecord;
         try {
-            annotatedRecord = annotator.annotateRecord(record, true, isoform, true);
+            annotatedRecord = annotator.annotateRecord(record, true, isoform, true, addColumns);
         }
         catch (HttpServerErrorException | ResourceAccessException e) {
            LOG.error("Failed to annotate record - errors accessing Genome Nexus");

--- a/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
+++ b/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsProcessor.java
@@ -59,6 +59,9 @@ public class AnnotateRecordsProcessor implements ItemProcessor<MutationEvent, Mu
     @Value("#{jobParameters['addColumns']}")
     private String addColumns;
 
+    @Value("#{jobParameters['prefix']}")
+    private String prefix;
+
     @Autowired
     Annotator annotator;
 
@@ -91,7 +94,7 @@ public class AnnotateRecordsProcessor implements ItemProcessor<MutationEvent, Mu
         MutationRecord record = annotator.createRecord(mafLine);
         AnnotatedRecord annotatedRecord;
         try {
-            annotatedRecord = annotator.annotateRecord(record, true, isoform, true, addColumns);
+            annotatedRecord = annotator.annotateRecord(record, true, isoform, true, addColumns, prefix);
         }
         catch (HttpServerErrorException | ResourceAccessException e) {
            LOG.error("Failed to annotate record - errors accessing Genome Nexus");


### PR DESCRIPTION
Add two command line parameter.
1. --add-columns
Adding fields to the output file, separate fields with ","
For example:  --add-columns variantType,variantClassification

2. --prefix
Adding prefix to the header of "add-columns" fields. 
For example: --prefix gn
Example output header: gn.variantType

may need some validation for column names in the future 