### PR TITLE
turn on error log by default

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -100,6 +100,6 @@ public class AnnotationPipeline
             !commandLine.hasOption("output-filename")) {
             help(gnuOptions, 0);
         }
-        launchJob(args, commandLine.getOptionValue("filename"), commandLine.getOptionValue("output-filename"), commandLine.getOptionValue("isoform-override"), commandLine.hasOption("error-report-location") ? commandLine.getOptionValue("error-report-location") : null, commandLine.hasOption("replace-symbol-entrez"), commandLine.hasOption("verbose"));
+        launchJob(args, commandLine.getOptionValue("filename"), commandLine.getOptionValue("output-filename"), commandLine.getOptionValue("isoform-override"), commandLine.hasOption("error-report-location") ? commandLine.getOptionValue("error-report-location") : null, commandLine.hasOption("replace-symbol-entrez"), commandLine.hasOption("verbose") ? Boolean.valueOf(commandLine.getOptionValue("verbose")) : true);
     }
 }


### PR DESCRIPTION
Turn on the error log by default. Can turn on/off the error log by adding `--verbose true` or `--verbose false`.
Fixes #89 