### PR TITLE
Configure jitpack to import cbioportal core module  only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,9 @@
     </dependency>
     <!-- cbioportal -->
     <dependency>
-      <groupId>com.github.cbioportal</groupId>
-      <artifactId>cbioportal</artifactId>
-      <version>rc-SNAPSHOT</version>
+      <groupId>com.github.cbioportal.cbioportal</groupId>
+      <artifactId>core</artifactId>
+      <version>c84ecb0bd6b6f32466a3e8a12c00f900e1b7af37</version>
     </dependency>
     <!-- api client -->
     <dependency>


### PR DESCRIPTION
JitPack has been importing te whole cbioportal as a dependency for the genome nexus annotation pipeline when we only need the cbioportal/core module. This update restricts the dependency to just the core module and successfully builds from the core/rc version of the cbioportal core module.

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>