### PR TITLE
Revert Change for Limiting cBio Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
     </dependency>
     <!-- cbioportal -->
     <dependency>
-      <groupId>com.github.cbioportal.cbioportal</groupId>
-      <artifactId>core</artifactId>
+      <groupId>com.github.cbioportal</groupId>
+      <artifactId>cbioportal</artifactId>
       <version>c84ecb0bd6b6f32466a3e8a12c00f900e1b7af37</version>
     </dependency>
     <!-- api client -->


### PR DESCRIPTION
only packing in core breaks pipelines importer (which pulls in cbio through genome nexus)
will increase build time but this can be addressed later (especially since we don't build importers regularly)

POTENTIAL TODO: split up dependencies to reduce build time, figure out solution for syncing everything up 