### PR TITLE
Added my_variant_info gnomad exome allele frequency fields

### DIFF
--- a/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2016 - 2020 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -38,7 +38,7 @@ import java.util.*;
  * @author Zachary Heins
  */
 
-public class AnnotatedRecord extends MutationRecord{
+public class AnnotatedRecord extends MutationRecord {
 
     protected String hgvsc;
     protected String hgvsp;
@@ -51,6 +51,15 @@ public class AnnotatedRecord extends MutationRecord{
     protected String hotspot;
     protected String consequence;
     protected String proteinPosition;
+    protected String gnomadAlleleFrequency;
+    protected String gnomadAlleleFrequencyAFR;
+    protected String gnomadAlleleFrequencyAMR;
+    protected String gnomadAlleleFrequencyASJ;
+    protected String gnomadAlleleFrequencyEAS;
+    protected String gnomadAlleleFrequencyFIN;
+    protected String gnomadAlleleFrequencyNFE;
+    protected String gnomadAlleleFrequencyOTH;
+    protected String gnomadAlleleFrequencySAS;
 
     public AnnotatedRecord() {
         addAnnotatedFieldsToHeader();
@@ -214,6 +223,35 @@ public class AnnotatedRecord extends MutationRecord{
         this.additionalProperties = additionalProperties;
     }
 
+    public void setGnomadFields(String gnomadAlleleFrequency,
+        String gnomadAlleleFrequencyAFR,
+        String gnomadAlleleFrequencyAMR,
+        String gnomadAlleleFrequencyASJ,
+        String gnomadAlleleFrequencyEAS,
+        String gnomadAlleleFrequencyFIN,
+        String gnomadAlleleFrequencyNFE,
+        String gnomadAlleleFrequencyOTH,
+        String gnomadAlleleFrequencySAS) {
+        header.add("gnomAD_AF");
+        header.add("gnomAD_AFR_AF");
+        header.add("gnomAD_AMR_AF");
+        header.add("gnomAD_ASJ_AF");
+        header.add("gnomAD_EAS_AF");
+        header.add("gnomAD_FIN_AF");
+        header.add("gnomAD_NFE_AF");
+        header.add("gnomAD_OTH_AF");
+        header.add("gnomAD_SAS_AF");
+        this.gnomadAlleleFrequency = gnomadAlleleFrequency;
+        this.gnomadAlleleFrequencyAFR = gnomadAlleleFrequencyAFR;
+        this.gnomadAlleleFrequencyAMR = gnomadAlleleFrequencyAMR;
+        this.gnomadAlleleFrequencyASJ = gnomadAlleleFrequencyASJ;
+        this.gnomadAlleleFrequencyEAS = gnomadAlleleFrequencyEAS;
+        this.gnomadAlleleFrequencyFIN = gnomadAlleleFrequencyFIN;
+        this.gnomadAlleleFrequencyNFE = gnomadAlleleFrequencyNFE;
+        this.gnomadAlleleFrequencyOTH = gnomadAlleleFrequencyOTH;
+        this.gnomadAlleleFrequencySAS = gnomadAlleleFrequencySAS;
+    }
+
     public String getHGVSC() {
         return this.hgvsc;
     }
@@ -284,6 +322,78 @@ public class AnnotatedRecord extends MutationRecord{
 
     public void setCONSEQUENCE(String consequence) {
         this.consequence = consequence;
+    }
+
+    public String getGNOMAD_AF() {
+        return this.gnomadAlleleFrequency;
+    }
+
+    public void setGNOMAD_AF(String gnomadAlleleFrequency) {
+        this.gnomadAlleleFrequency = gnomadAlleleFrequency;
+    }
+
+    public String getGNOMAD_AFR_AF() {
+        return this.gnomadAlleleFrequencyAFR;
+    }
+
+    public void setGNOMAD_AFR_AF(String gnomadAlleleFrequencyAFR) {
+        this.gnomadAlleleFrequencyAFR = gnomadAlleleFrequencyAFR;
+    }
+
+    public String getGNOMAD_AMR_AF() {
+        return this.gnomadAlleleFrequencyAMR;
+    }
+
+    public void setGNOMAD_AMR_AF(String gnomadAlleleFrequencyAMR) {
+        this.gnomadAlleleFrequencyAMR = gnomadAlleleFrequencyAMR;
+    }
+
+    public String getGNOMAD_ASJ_AF() {
+        return this.gnomadAlleleFrequencyASJ;
+    }
+
+    public void setGNOMAD_ASJ_AF(String gnomadAlleleFrequencyASJ) {
+        this.gnomadAlleleFrequencyASJ = gnomadAlleleFrequencyASJ;
+    }
+
+    public String getGNOMAD_EAS_AF() {
+        return this.gnomadAlleleFrequencyEAS;
+    }
+
+    public void setGNOMAD_EAS_AF(String gnomadAlleleFrequencyEAS) {
+        this.gnomadAlleleFrequencyEAS = gnomadAlleleFrequencyEAS;
+    }
+
+    public String getGNOMAD_FIN_AF() {
+        return this.gnomadAlleleFrequencyFIN;
+    }
+
+    public void setGNOMAD_FIN_AF(String gnomadAlleleFrequencyFIN) {
+        this.gnomadAlleleFrequencyFIN = gnomadAlleleFrequencyFIN;
+    }
+
+    public String getGNOMAD_NFE_AF() {
+        return this.gnomadAlleleFrequencyNFE;
+    }
+
+    public void setGNOMAD_NFE_AF(String gnomadAlleleFrequencyNFE) {
+        this.gnomadAlleleFrequencyNFE = gnomadAlleleFrequencyNFE;
+    }
+
+    public String getGNOMAD_OTH_AF() {
+        return this.gnomadAlleleFrequencyOTH;
+    }
+
+    public void setGNOMAD_OTH_AF(String gnomadAlleleFrequencyOTH) {
+        this.gnomadAlleleFrequencyOTH = gnomadAlleleFrequencyOTH;
+    }
+
+    public String getGNOMAD_SAS_AF() {
+        return this.gnomadAlleleFrequencySAS;
+    }
+
+    public void setGNOMAD_SAS_AF(String gnomadAlleleFrequencySAS) {
+        this.gnomadAlleleFrequencySAS = gnomadAlleleFrequencySAS;
     }
 
     private void addAnnotatedFieldsToHeader() {

--- a/annotator/src/test/java/org/cbioportal/annotator/GenomeNexusTestConfiguration.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/GenomeNexusTestConfiguration.java
@@ -44,5 +44,6 @@ public class GenomeNexusTestConfiguration {
     public final static String GENOME_NEXUS_BASE_URL = "http://annotation.genomenexus.org/";
     public final static String ISOFORM_QUERY_PARAMETER = "isoformOverrideSource";
     public final static String ENRICHMENT_FIELDS = "fields=hotspots";
+    public final static String MY_VARIANT_INFO_ENRICHMENT_FIELDS = "fields=annotation_summary,my_variant_info";
 
 }

--- a/annotator/src/test/java/org/cbioportal/annotator/MockGenomeNexusImpl.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/MockGenomeNexusImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Memorial Sloan-Kettering Cancer Center.
+ * Copyright (c) 2018 - 2020 Memorial Sloan-Kettering Cancer Center.
  *
  * This library is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY, WITHOUT EVEN THE IMPLIED WARRANTY OF MERCHANTABILITY OR FITNESS
@@ -32,6 +32,10 @@
 
 package org.cbioportal.annotator;
 
+import org.cbioportal.annotator.mixin.AlleleFrequencyMixin;
+import org.cbioportal.annotator.mixin.GnomadMixin;
+import org.cbioportal.annotator.mixin.MyVariantInfoMixin;
+import org.cbioportal.annotator.mixin.MyVariantInfoAnnotationMixin;
 import org.cbioportal.annotator.mixin.TranscriptConsequenceMixin;
 import org.cbioportal.annotator.mixin.VariantAnnotationMixin;
 import org.cbioportal.models.AnnotatedRecord;
@@ -44,6 +48,10 @@ import java.util.*;
 import org.cbioportal.annotator.mixin.TranscriptConsequenceSummaryMixin;
 import org.cbioportal.annotator.mixin.VariantAnnotationSummaryMixin;
 
+import org.genome_nexus.client.AlleleFrequency;
+import org.genome_nexus.client.Gnomad;
+import org.genome_nexus.client.MyVariantInfo;
+import org.genome_nexus.client.MyVariantInfoAnnotation;
 import org.genome_nexus.client.TranscriptConsequence;
 import org.genome_nexus.client.TranscriptConsequenceSummary;
 import org.genome_nexus.client.VariantAnnotation;
@@ -108,6 +116,14 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
         this.mockGenomeNexusHgvsPOSTResponseMap = map;
     }
 
+    private Map<String, String> mockGenomeNexusMyVariantInfoResponseMap = new HashMap<>();
+    @Autowired
+    private void setMockGenomeNexusMyVariantInfoResponseMap() {
+        Map<String, String> map = new HashMap<>();
+        map.put("4,9784947,9784948,-,AGA", "{\"variant\":\"4:g.9784947_9784948insAGA\",\"hgvsg\":\"4:g.9784947_9784948insAGA\",\"id\":\"4:g.9784947_9784948insAGA\",\"assembly_name\":\"GRCh37\",\"seq_region_name\":\"4\",\"start\":9784948,\"end\":9784947,\"allele_string\":\"-/AGA\",\"strand\":1,\"most_severe_consequence\":\"protein_altering_variant\",\"transcript_consequences\":[{\"exon\":\"1/1\",\"transcript_id\":\"ENST00000304374\",\"hgvsp\":\"ENSP00000306129.2:p.Gly432delinsGluSer\",\"hgvsc\":\"ENST00000304374.2:c.1294_1295insAGA\",\"variant_allele\":\"AGA\",\"codons\":\"ggt/gAGAgt\",\"protein_id\":\"ENSP00000306129\",\"protein_start\":432,\"protein_end\":432,\"gene_symbol\":\"DRD5\",\"gene_id\":\"ENSG00000169676\",\"amino_acids\":\"G/ES\",\"hgnc_id\":\"3026\",\"canonical\":\"1\",\"refseq_transcript_ids\":[\"NM_000798.4\"],\"consequence_terms\":[\"protein_altering_variant\"]},{\"transcript_id\":\"ENST00000503803\",\"hgvsc\":\"ENST00000503803.1:n.386-3259_386-3258insTCT\",\"variant_allele\":\"AGA\",\"gene_symbol\":\"SLC2A9\",\"gene_id\":\"ENSG00000109667\",\"hgnc_id\":\"13446\",\"consequence_terms\":[\"intron_variant\",\"non_coding_transcript_variant\"]},{\"transcript_id\":\"ENST00000508585\",\"hgvsc\":\"ENST00000508585.1:n.182-11955_182-11954insTCT\",\"variant_allele\":\"AGA\",\"gene_symbol\":\"SLC2A9\",\"gene_id\":\"ENSG00000109667\",\"hgnc_id\":\"13446\",\"consequence_terms\":[\"intron_variant\",\"non_coding_transcript_variant\"]}],\"annotation_summary\":{\"variant\":\"4:g.9784947_9784948insAGA\",\"genomicLocation\":{\"chromosome\":\"4\",\"start\":9784947,\"end\":9784948,\"referenceAllele\":\"-\",\"variantAllele\":\"AGA\"},\"strandSign\":\"+\",\"variantType\":\"INS\",\"assemblyName\":\"GRCh37\",\"canonicalTranscriptId\":\"ENST00000304374\",\"transcriptConsequences\":[{\"transcriptId\":\"ENST00000304374\",\"codonChange\":\"ggt/gAGAgt\",\"entrezGeneId\":\"1816\",\"consequenceTerms\":\"protein_altering_variant\",\"hugoGeneSymbol\":\"DRD5\",\"hgvspShort\":\"p.G432delinsES\",\"hgvsp\":\"p.Gly432delinsGluSer\",\"hgvsc\":\"ENST00000304374.2:c.1294_1295insAGA\",\"proteinPosition\":{\"start\":432,\"end\":432},\"refSeq\":\"NM_000798.4\",\"variantClassification\":\"In_Frame_Ins\",\"exon\":\"1/1\"}],\"transcriptConsequenceSummaries\":[{\"transcriptId\":\"ENST00000304374\",\"codonChange\":\"ggt/gAGAgt\",\"entrezGeneId\":\"1816\",\"consequenceTerms\":\"protein_altering_variant\",\"hugoGeneSymbol\":\"DRD5\",\"hgvspShort\":\"p.G432delinsES\",\"hgvsp\":\"p.Gly432delinsGluSer\",\"hgvsc\":\"ENST00000304374.2:c.1294_1295insAGA\",\"proteinPosition\":{\"start\":432,\"end\":432},\"refSeq\":\"NM_000798.4\",\"variantClassification\":\"In_Frame_Ins\",\"exon\":\"1/1\"},{\"transcriptId\":\"ENST00000503803\",\"entrezGeneId\":\"56606\",\"consequenceTerms\":\"intron_variant,non_coding_transcript_variant\",\"hugoGeneSymbol\":\"SLC2A9\",\"hgvspShort\":\"*129*\",\"hgvsc\":\"ENST00000503803.1:n.386-3259_386-3258insTCT\",\"variantClassification\":\"Intron\"},{\"transcriptId\":\"ENST00000508585\",\"entrezGeneId\":\"56606\",\"consequenceTerms\":\"intron_variant,non_coding_transcript_variant\",\"hugoGeneSymbol\":\"SLC2A9\",\"hgvspShort\":\"*61*\",\"hgvsc\":\"ENST00000508585.1:n.182-11955_182-11954insTCT\",\"variantClassification\":\"Intron\"}],\"transcriptConsequenceSummary\":{\"transcriptId\":\"ENST00000304374\",\"codonChange\":\"ggt/gAGAgt\",\"entrezGeneId\":\"1816\",\"consequenceTerms\":\"protein_altering_variant\",\"hugoGeneSymbol\":\"DRD5\",\"hgvspShort\":\"p.G432delinsES\",\"hgvsp\":\"p.Gly432delinsGluSer\",\"hgvsc\":\"ENST00000304374.2:c.1294_1295insAGA\",\"proteinPosition\":{\"start\":432,\"end\":432},\"refSeq\":\"NM_000798.4\",\"variantClassification\":\"In_Frame_Ins\",\"exon\":\"1/1\"}},\"my_variant_info\": { \"annotation\": { \"gnomadExome\": {\"alleleFrequency\":{\"af\":0.000449569,\"af_afr\":0,\"af_amr\":0.0000578704,\"af_asj\":0.00773963,\"af_eas\":0,\"af_fin\":0.0000461979,\"af_nfe\":0.000228704,\"af_oth\":0.000978155,\"af_sas\":0}}}}}");
+        this.mockGenomeNexusMyVariantInfoResponseMap = map;
+    }
+
     @Bean
     @Override
     public MockGenomeNexusImpl annotator() {
@@ -138,6 +154,18 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
         return convertResponseToAnnotatedRecord(gnResponse, record, REPLACE);
     }
 
+    public AnnotatedRecord makeMockMyVariantInfoAnnotatedRecord(MutationRecord record) {
+        VariantAnnotation gnResponse = null;
+        try {
+            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusMyVariantInfoResponseMap.get(extractGenomicLocationAsString(record)));
+        }
+        catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return convertResponseToAnnotatedRecord(gnResponse, record, REPLACE);
+    }
+
     private VariantAnnotation makeMockGenomeNexusResponse(String mockReturnJsonString) throws IOException {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setMixInAnnotations(this.initMixinMap());
@@ -152,6 +180,10 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
         mixinMap.put(TranscriptConsequence.class, TranscriptConsequenceMixin.class);
         mixinMap.put(TranscriptConsequenceSummary.class, TranscriptConsequenceSummaryMixin.class);
         mixinMap.put(VariantAnnotationSummary.class, VariantAnnotationSummaryMixin.class);
+        mixinMap.put(MyVariantInfoAnnotation.class, MyVariantInfoAnnotationMixin.class);
+        mixinMap.put(MyVariantInfo.class, MyVariantInfoMixin.class);
+        mixinMap.put(Gnomad.class, GnomadMixin.class);
+        mixinMap.put(AlleleFrequency.class, AlleleFrequencyMixin.class);
 
         return mixinMap;
     }

--- a/annotator/src/test/java/org/cbioportal/annotator/internal/GenomeNexusImplTest.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/internal/GenomeNexusImplTest.java
@@ -186,6 +186,35 @@ public class GenomeNexusImplTest {
         }
     }
 
+    @Test
+    public void testGnomadAnnotationResultsExcluded() throws Exception {
+        // test records that should not have the gnomad records
+        for (AnnotatedRecord record : mockAnnotatedRecordsWithPost) {
+            if (record.getGNOMAD_AF() != null) {
+                Assert.fail("testGnomadAnnotationResultsExcluded(), annotated record includes GNOMAD_AF when it should not, value is: '" + record.getGNOMAD_AF() + "'");
+            }
+        }
+    }
+
+    @Test
+    public void testGnomadAnnotationResultsIncluded() throws Exception {
+        // annotate now with my_variant_info included in enrichmentFields
+        ReflectionTestUtils.setField(annotator, "enrichmentFields", GenomeNexusTestConfiguration.MY_VARIANT_INFO_ENRICHMENT_FIELDS);
+
+        String expectedValue = "4.49569E-4";
+
+        AnnotatedRecord record = annotator.makeMockMyVariantInfoAnnotatedRecord(mockAnnotatedRecordsWithPost.get(0));
+        if (record.getGNOMAD_AF() == null) {
+            Assert.fail("testGnomadAnnotationResultsIncluded(), annotated record does not have GNOMAD_AF value when my_variant_info was included, expected value is: '" + expectedValue + "', value is null");
+        }
+        if (!record.getGNOMAD_AF().equals(expectedValue)) {
+            Assert.fail("testGnomadAnnotationResultsIncluded(), expected annotated record to have GNOMAD_AF = '" + expectedValue + "', instead it has: '" + record.getGNOMAD_AF() + "'");
+        }
+
+        // reset enrichment fields
+        ReflectionTestUtils.setField(annotator, "enrichmentFields", GenomeNexusTestConfiguration.ENRICHMENT_FIELDS);
+    }
+
     private List<AnnotatedRecord> makeMockAnnotatedRecordsWithPost() {
         List<MutationRecord> mockMutationRecords = makeMockMutationRecords();
         List<AnnotatedRecord> mockAnnotatedRecordsWithPost = new ArrayList();

--- a/annotator/src/test/java/org/cbioportal/annotator/mixin/AlleleFrequencyMixin.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/mixin/AlleleFrequencyMixin.java
@@ -1,0 +1,34 @@
+package org.cbioportal.annotator.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AlleleFrequencyMixin {
+    @JsonProperty("af")
+    private Double af;
+
+    @JsonProperty("af_afr")
+    private Double afAfr;
+
+    @JsonProperty("af_amr")
+    private Double afAmr;
+
+    @JsonProperty("af_asj")
+    private Double afAsj;
+
+    @JsonProperty("af_eas")
+    private Double afEas;
+
+    @JsonProperty("af_fin")
+    private Double afFin;
+    
+    @JsonProperty("af_nfe")
+    private Double afNfe;
+
+    @JsonProperty("af_oth")
+    private Double afOth;
+
+    @JsonProperty("af_sas")
+    private Double afSas;
+}

--- a/annotator/src/test/java/org/cbioportal/annotator/mixin/GnomadMixin.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/mixin/GnomadMixin.java
@@ -1,0 +1,11 @@
+package org.cbioportal.annotator.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.genome_nexus.client.AlleleFrequency;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GnomadMixin {
+    @JsonProperty("alleleFrequency")
+    private AlleleFrequency alleleFrequency;
+}

--- a/annotator/src/test/java/org/cbioportal/annotator/mixin/MyVariantInfoAnnotationMixin.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/mixin/MyVariantInfoAnnotationMixin.java
@@ -1,0 +1,11 @@
+package org.cbioportal.annotator.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.genome_nexus.client.MyVariantInfo;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MyVariantInfoAnnotationMixin {
+    @JsonProperty("annotation")
+    private MyVariantInfo annotation;
+}

--- a/annotator/src/test/java/org/cbioportal/annotator/mixin/MyVariantInfoMixin.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/mixin/MyVariantInfoMixin.java
@@ -1,0 +1,11 @@
+package org.cbioportal.annotator.mixin;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.genome_nexus.client.Gnomad;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MyVariantInfoMixin {
+    @JsonProperty("gnomadExome")
+    private Gnomad gnomadExome;
+}

--- a/annotator/src/test/java/org/cbioportal/annotator/mixin/VariantAnnotationMixin.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/mixin/VariantAnnotationMixin.java
@@ -2,6 +2,7 @@ package org.cbioportal.annotator.mixin;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.genome_nexus.client.MyVariantInfoAnnotation;
 import org.genome_nexus.client.TranscriptConsequence;
 import org.genome_nexus.client.VariantAnnotationSummary;
 
@@ -32,4 +33,6 @@ public class VariantAnnotationMixin
     private String variant;
     @JsonProperty("annotation_summary")
     private VariantAnnotationSummary annotationSummary;
+    @JsonProperty("my_variant_info")
+    private MyVariantInfoAnnotation myVariantInfo;
 }


### PR DESCRIPTION
If 'my_variant_info' is included in the enrichment fields then the following fields will now be included in the output MAF:

gnomAD_AF
gnomAD_AFR_AF
gnomAD_AMR_AF
gnomAD_ASJ_AF
gnomAD_EAS_AF
gnomAD_FIN_AF
gnomAD_NFE_AF
gnomAD_OTH_AF
gnomAD_SAS_AF

Which will come from the following Genome Nexus JSON:

```"my_variant_info": { "annotation": { "gnomadExome": {"alleleFrequency": { "af": 0, "af_afr": 0, "af_amr": 0, "af_asj": 0, "af_eas": 0, "af_fin": 0, "af_nfe": 0, "af_oth": 0, "af_sas": 0 }}}}```