### PR TITLE
output to System.out when empty files are skipped

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -99,6 +99,7 @@ public class MutationRecordReader implements ItemStreamReader<AnnotatedRecord> {
                 summaryStatistics.saveErrorMessagesToFile(errorReportLocation);
             }
         } else {
+            System.out.println("It seems that the input mutation file does not contain any mutation records. Exiting without writing an output file.");
             LOG.warn("Did not extract any records from the MAF, nothing to process - ending annotation job...");
         }
         // always add size of "allAnnotatedRecords" to execution context

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -815,7 +815,7 @@ public class GenomeNexusImpl implements Annotator {
             start = end;
             end = start + postIntervalSize;
         }
-        if (end > sortedGenomicLocations.size()) {
+        if (start < sortedGenomicLocations.size()) {
             genomicLocationPartitionedLists.add(sortedGenomicLocations.subList(start, sortedGenomicLocations.size()));
         }
         return genomicLocationPartitionedLists;


### PR DESCRIPTION
    output to System.out when empty files are skipped
    - System.out used to match the output destination of printSummaryStatistics
    avoid passing empty lists for annotation to genome nexus
    - when the size of the query to genome nexus was an exact multiple of the slice size, an extra empty request was being sent
