### PR TITLE
Use core module only

### DIFF
--- a/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsWriter.java
+++ b/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/AnnotateRecordsWriter.java
@@ -32,7 +32,6 @@
 
 package org.cbioportal.database.annotator;
 
-import com.mysql.jdbc.exceptions.jdbc4.MySQLIntegrityConstraintViolationException;
 import static com.querydsl.core.alias.Alias.$;
 import static com.querydsl.core.alias.Alias.alias;
 import com.querydsl.core.types.Projections;
@@ -100,7 +99,7 @@ public class AnnotateRecordsWriter  implements ItemStreamWriter<MutationEvent>{
                 Integer rs = pstmt.executeUpdate();
                 log.info("Updated mutation event. Mutation event id: " + annotatedEvent.getMUTATION_EVENT_ID());
             }
-            catch (MySQLIntegrityConstraintViolationException e) {
+            catch (SQLIntegrityConstraintViolationException e) {
                 List<MutationEvent> mutationEvents = getDuplicatedMutationEvents(annotatedEvent);
                 for (MutationEvent event : mutationEvents) {
                     if (event.getPROTEIN_CHANGE().equals(annotatedEvent.getPROTEIN_CHANGE())) {

--- a/pom.xml
+++ b/pom.xml
@@ -67,15 +67,9 @@
 
     <!-- cbioportal -->
     <dependency>
-      <groupId>com.github.cbioportal</groupId>
-      <artifactId>cbioportal</artifactId>
-      <version>45f22a67ed6fce0e3ceb6805548f3ee1cefc8e44</version>
-      <exclusions>
-          <exclusion>
-              <groupId>org.apache.logging.log4j</groupId>
-              <artifactId>log4j-core</artifactId>
-          </exclusion>
-      </exclusions>
+      <groupId>com.github.cbioportal.cbioportal</groupId>
+	  <artifactId>core</artifactId>
+      <version>v3.6.2</version>
     </dependency>
     <!-- allows junit3 or juni4 tests to run in the juni5 environment -->
     <dependency>


### PR DESCRIPTION
Using the core module instead of the entire portal package somehow
solves the problem. That did lack some deps such as log4j and mysql. A
quick hack was to just include the log4j dep from cbioportal. Instead of
the mysql package, I think we can use vanilla sql according to this
stackoverflow answer: https://stackoverflow.com/a/27582891/1894184.

WARNING: we tried to include only the core module before and that caused some issue for a pipeline package downstream (see https://github.com/genome-nexus/genome-nexus-annotation-pipeline/pull/107). That might still be an issue. Maybe we can figure out a way to change these downstream deps to not depend on the entire portal package CC @averyniceday ?