### PR TITLE
Handle logging changes for cbioportal 3.6.4 plus upgrade to 3.7.0

### DIFF
--- a/annotationPipeline/pom.xml
+++ b/annotationPipeline/pom.xml
@@ -58,4 +58,14 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <!-- required to build an executable jar -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -35,8 +35,8 @@ package org.cbioportal.annotation;
 import org.cbioportal.annotation.pipeline.BatchConfiguration;
 
 import org.apache.commons.cli.*;
-import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.batch.core.*;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -72,8 +72,7 @@ public class AnnotationPipeline
     private static void launchJob(String[] args, String filename, String outputFilename, String isoformOverride,
             String errorReportLocation, boolean replace, Integer postIntervalSize) throws Exception
     {
-        SpringApplication app = new SpringApplication(AnnotationPipeline.class);
-        ConfigurableApplicationContext ctx = app.run(args);
+        ConfigurableApplicationContext ctx = new SpringApplicationBuilder(AnnotationPipeline.class).web(false).run(args);
         JobLauncher jobLauncher = ctx.getBean(JobLauncher.class);
 
         Job annotationJob = ctx.getBean(BatchConfiguration.ANNOTATION_JOB, Job.class);

--- a/annotator/pom.xml
+++ b/annotator/pom.xml
@@ -33,6 +33,29 @@
       <artifactId>commons-cli</artifactId>
       <version>1.3</version>
     </dependency>
+    <dependency>
+        <groupId>javax.xml.bind</groupId>
+         <artifactId>jaxb-api</artifactId>
+        <version>2.3.0</version>
+     </dependency>
+    <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>1.3.156</version>
+    </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- required to build an executable jar -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+            <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/databaseAnnotator/pom.xml
+++ b/databaseAnnotator/pom.xml
@@ -118,4 +118,14 @@
     </repository>
   </repositories>
 
+  <build>
+    <plugins>
+      <plugin>
+        <!-- required to build an executable jar -->
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/DataSourceConfiguration.java
+++ b/databaseAnnotator/src/main/java/org/cbioportal/database/annotator/DataSourceConfiguration.java
@@ -38,7 +38,6 @@ import java.sql.SQLException;
 import org.apache.commons.dbcp.BasicDataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
 import org.springframework.beans.factory.annotation.Value;
 
 /**
@@ -61,7 +60,7 @@ public class DataSourceConfiguration {
     @Value("${databaseannotator.connection_string}")
     private String connection_string;
 
-    @Bean
+    @Bean(destroyMethod = "")
     public SQLQueryFactory databaseAnnotatorQueryFactory() throws SQLException {
         MySQLTemplates templates = new MySQLTemplates();
         com.querydsl.sql.Configuration config = new com.querydsl.sql.Configuration(templates);

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.2.7.RELEASE</version>
+    <version>1.4.7.RELEASE</version>
   </parent>
 
   <properties>
@@ -69,7 +69,13 @@
     <dependency>
       <groupId>com.github.cbioportal.cbioportal</groupId>
 	  <artifactId>core</artifactId>
-      <version>v3.6.2</version>
+      <version>24bc8b56d73cacb33a1601e3a60160ceff2fa13d</version>
+      <exclusions>
+          <exclusion>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-core</artifactId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <!-- allows junit3 or juni4 tests to run in the juni5 environment -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.github.cbioportal.cbioportal</groupId>
 	  <artifactId>core</artifactId>
-      <version>24bc8b56d73cacb33a1601e3a60160ceff2fa13d</version>
+      <version>c6567af85d673ded1935805258dca4a5195c52a7</version>
       <exclusions>
           <exclusion>
               <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
This combines #165 with the logging changes + #175 the 3.7.0 upgrade. The standalone upgrade to 3.7.0 didn't work, because it needs the logging changes

The description of https://github.com/genome-nexus/genome-nexus-annotation-pipeline/pull/165 is better, so please see the discussion there for a better explanation of the changes

Note that there is a failing test, but it is already failing in master. We should address those in a separate PR. I'm guessing they are actually server issues since we get a status of annotation failed in the MAF

This supersedes #165 and #175