### PR TITLE
Use post method as default

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/AnnotateSubcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/AnnotateSubcommand.java
@@ -55,4 +55,9 @@ public class AnnotateSubcommand implements Subcommand {
         return commandLine.getOptionValue(opt);
     }
 
+    @Override
+    public String getOptionValue(String opt, String defaultValue) {
+        return commandLine.getOptionValue(opt, defaultValue);
+    }
+
 }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/MergeSubcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/MergeSubcommand.java
@@ -53,4 +53,9 @@ public class MergeSubcommand implements Subcommand {
     public String getOptionValue(String opt) {
         return commandLine.getOptionValue(opt);
     }
+
+    @Override
+    public String getOptionValue(String opt, String defaultValue) {
+        return commandLine.getOptionValue(opt, defaultValue);
+    }
 }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/Subcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/Subcommand.java
@@ -18,4 +18,6 @@ public interface Subcommand {
     boolean hasOption(String opt);
 
     String getOptionValue(String opt);
+
+    String getOptionValue(String opt, String defaultValue);
 }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/pipeline/MutationRecordReader.java
@@ -71,10 +71,10 @@ public class MutationRecordReader implements ItemStreamReader<AnnotatedRecord> {
     @Value("#{jobParameters[isoformOverride]}")
     private String isoformOverride;
 
-    @Value("#{jobParameters[errorReportLocation]}")
+    @Value("#{jobParameters[errorReportLocation] ?: ''}")
     private String errorReportLocation;
 
-    @Value("#{jobParameters[postIntervalSize]}")
+    @Value("#{jobParameters[postIntervalSize] ?: '100'}")
     private Integer postIntervalSize;
 
     @Value("#{jobParameters[outputFormat]}")
@@ -97,7 +97,7 @@ public class MutationRecordReader implements ItemStreamReader<AnnotatedRecord> {
         processComments(ec, genomeNexusVersion);
         List<MutationRecord> mutationRecords = loadMutationRecordsFromMaf();
         if (!mutationRecords.isEmpty()) {
-            if (postIntervalSize > 0) {
+            if (postIntervalSize > 1) {
                 allAnnotatedRecords = annotator.getAnnotatedRecordsUsingPOST(summaryStatistics, mutationRecords, isoformOverride, replace, postIntervalSize, true);
             } else {
                 allAnnotatedRecords = annotator.annotateRecordsUsingGET(summaryStatistics, mutationRecords, isoformOverride, replace, true);
@@ -141,9 +141,7 @@ public class MutationRecordReader implements ItemStreamReader<AnnotatedRecord> {
             }
             ec.put("mutation_header", new ArrayList(header));
             summaryStatistics.printSummaryStatistics();
-            if (errorReportLocation != null) {
-                summaryStatistics.saveErrorMessagesToFile(errorReportLocation);
-            }
+            summaryStatistics.saveErrorMessagesToFile(errorReportLocation);
         } else {
             System.out.println("It seems that the input mutation file does not contain any mutation records. Exiting without writing an output file.");
             LOG.warn("Did not extract any records from the MAF, nothing to process - ending annotation job...");

--- a/annotationPipeline/src/test/java/org/cbioportal/annotation/AnnotationPipelineTest.java
+++ b/annotationPipeline/src/test/java/org/cbioportal/annotation/AnnotationPipelineTest.java
@@ -1,7 +1,7 @@
 package org.cbioportal.annotation;
 
 
-import org.apache.tools.ant.types.Path;
+import org.cbioportal.annotation.cli.AnnotationFailedException;
 import org.cbioportal.annotation.cli.MergeFailedException;
 import org.cbioportal.annotation.cli.NoSubcommandFoundException;
 import org.junit.jupiter.api.Test;
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Files;
-import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -159,5 +158,59 @@ class AnnotationPipelineTest {
         } catch (Exception ignored) {
         }
         fail("Test didn't produced a MergeFailedException");
+    }
+
+    /**
+     * annotate with no input, should produce AnnotationFailedException
+     */
+    @Test
+    void annotate_test_1() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            final Logger logger = mock(Logger.class, RETURNS_DEEP_STUBS);
+            loggerFactory.when(() -> LoggerFactory.getLogger(AnnotationPipeline.class)).thenReturn(logger);
+            String[] args = {"annotate"};
+            AnnotationPipeline.main(args);
+        } catch (AnnotationFailedException e) {
+            assertEquals("required option: filename", e.getMessage());
+            return;
+        } catch (Exception ignored) {
+        }
+        fail("Test didn't produced a AnnotationFailedException");
+    }
+
+    /**
+     * annotate with no output-filename option, should produce AnnotationFailedException
+     */
+    @Test
+    void annotate_test_2() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            final Logger logger = mock(Logger.class, RETURNS_DEEP_STUBS);
+            loggerFactory.when(() -> LoggerFactory.getLogger(AnnotationPipeline.class)).thenReturn(logger);
+            String[] args = {"annotate", "--filename", "a"};
+            AnnotationPipeline.main(args);
+        } catch (AnnotationFailedException e) {
+            assertEquals("required option: output-filename", e.getMessage());
+            return;
+        } catch (Exception ignored) {
+        }
+        fail("Test didn't produced a AnnotationFailedException");
+    }
+
+    /**
+     * annotate with invalid output-format option, should produce AnnotationFailedException
+     */
+    @Test
+    void annotate_test_3() {
+        try (MockedStatic<LoggerFactory> loggerFactory = mockStatic(LoggerFactory.class)) {
+            final Logger logger = mock(Logger.class, RETURNS_DEEP_STUBS);
+            loggerFactory.when(() -> LoggerFactory.getLogger(AnnotationPipeline.class)).thenReturn(logger);
+            String[] args = {"annotate", "--filename", "a", "--output-filename", "b" , "--output-format", "c"};
+            AnnotationPipeline.main(args);
+        } catch (AnnotationFailedException e) {
+            assertEquals("Error while reading output-format file: " + "c", e.getMessage());
+            return;
+        } catch (Exception ignored) {
+        }
+        fail("Test didn't produced a AnnotationFailedException");
     }
 }

--- a/annotationPipeline/src/test/java/org/cbioportal/annotation/SpringBatchIntegrationTest.java
+++ b/annotationPipeline/src/test/java/org/cbioportal/annotation/SpringBatchIntegrationTest.java
@@ -71,7 +71,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(false))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -89,7 +88,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(false))
                 .addString("isoformOverride", "mskcc")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -107,7 +105,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -125,7 +122,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -143,7 +139,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "mskcc")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -161,7 +156,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -179,7 +173,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "mskcc")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -202,7 +195,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(false))
                 .addString("isoformOverride", "mskcc")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -225,7 +217,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(false))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -243,7 +234,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(true))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }
@@ -261,7 +251,6 @@ public class SpringBatchIntegrationTest {
                 .addString("replace", String.valueOf(false))
                 .addString("isoformOverride", "uniprot")
                 .addString("errorReportLocation", null)
-                .addString("postIntervalSize", String.valueOf(-1))
                 .toJobParameters();
         testWith(jobParameters, expectedFile, actualFile);
     }

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
@@ -152,6 +152,7 @@ private final List<String> ERROR_FILE_HEADER = Arrays.asList(new String[]{"SAMPL
     }
 
     public void saveErrorMessagesToFile(String filename) {
+        if(filename == null || filename.isEmpty()) return;
         if (this.failedAnnotatedRecordsErrorMessages.isEmpty()) {
             LOG.info("No errors to write - error report will not be generated.");
         }


### PR DESCRIPTION
By default, it uses the post method with a postIntervalSize of 100 
In order to use the get method you have to set postIntervalSize to 1
It improved the duration of total test cases by more than 50%