### PR TITLE
Change ENTRYPOINT to CMD for run flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY --from=0 $GN_HOME/annotationPipeline/target/annotationPipeline-*.jar $GN_HO
 
 COPY annotationPipeline/src/main/resources/application.properties.EXAMPLE $GN_HOME/annotationPipeline/src/main/resources/application.properties
 
-ENTRYPOINT ["java", "-jar", "/genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar"]
+CMD ["java", "-jar", "/genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar"]


### PR DESCRIPTION
Nextflow has deprecated support for executable containers. e.g ENTRYPOINT defaults.
[529](https://github.com/nextflow-io/nextflow/issues/529) 

Changing ENTRYPOINT to CMD would keep the default behavior of running annotationPipeline.jar. It also has the added benefit of possibly pulling in [annotation-tools](https://github.com/genome-nexus/annotation-tools/tree/master)