### PR TITLE
Add server version to version sub command

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -152,7 +152,7 @@ public class AnnotationPipeline {
             return;
         }
         System.out.println("Client: " + getAppVersion());
-        System.out.println("Server: " + subcommand.getServerVersion());
+        System.out.println(subcommand.getformattedServerVersion());
     }
 
     private static void merge(Subcommand subcommand) throws MergeFailedException {

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -121,7 +121,7 @@ public class AnnotationPipeline {
         } else if (subcommand instanceof MergeSubcommand) {
             merge(subcommand);
         } else if (subcommand instanceof VersionSubcommand) {
-            version(subcommand);
+            version((VersionSubcommand) subcommand);
         }
     }
 
@@ -146,12 +146,13 @@ public class AnnotationPipeline {
         return appVersion;
     }
 
-    private static void version(Subcommand subcommand) {
+    private static void version(VersionSubcommand subcommand) {
         if (subcommand.hasOption("h")) {
             subcommand.printHelp();
             return;
         }
         System.out.println("Client: " + getAppVersion());
+        System.out.println("Server: " + subcommand.getServerVersion());
     }
 
     private static void merge(Subcommand subcommand) throws MergeFailedException {

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
@@ -1,5 +1,7 @@
 package org.cbioportal.annotation.cli;
 
+import java.util.stream.Collectors;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
@@ -35,7 +37,8 @@ public class VersionSubcommand implements Subcommand {
             return "Server: " + result.getGenomeNexus().getServer().getVersion() + System.lineSeparator() +
              "Annotation Sources" + System.lineSeparator() +
              "    " + "VEP Server: " +result.getVep().getServer().getVersion() + System.lineSeparator() +
-             "    " + "VEP Cache: "  +result.getVep().getCache().getVersion();
+             "    " + "VEP Cache: "  +result.getVep().getCache().getVersion() + System.lineSeparator() +
+             result.getAnnotationSourcesInfo().stream().map(source -> "    " + source.getName() + ": " + source.getVersion()).collect(Collectors.joining(System.lineSeparator()));
         } catch (ApiException e) {
             LOG.error("Exception when calling InfoControllerApi#fetchVersionGET, genome nexus version is unknown", e);
         }

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
@@ -3,9 +3,17 @@ package org.cbioportal.annotation.cli;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+import org.genome_nexus.ApiException;
+import org.genome_nexus.client.AggregateSourceInfo;
+import org.genome_nexus.client.InfoControllerApi;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 
 public class VersionSubcommand implements Subcommand {
     private static Options options;
+    private static final String UKNOWN_GENOME_NEXUS_VERSION = "unknown";
+    private final Logger LOG = LoggerFactory.getLogger(VersionSubcommand.class);
 
     static {
         options = getOptions();
@@ -18,6 +26,17 @@ public class VersionSubcommand implements Subcommand {
 
     public VersionSubcommand(String[] args) throws ParseException {
         commandLine = Subcommands.getCommandLine(args, options);
+    }
+
+    public String getServerVersion() {
+        InfoControllerApi infoApiClient = new InfoControllerApi();
+        try {
+            AggregateSourceInfo result = infoApiClient.fetchVersionGET();
+            return result.getGenomeNexus().getServer().getVersion();
+        } catch (ApiException e) {
+            LOG.error("Exception when calling InfoControllerApi#fetchVersionGET, genome nexus version is unknown", e);
+        }
+        return UKNOWN_GENOME_NEXUS_VERSION;
     }
 
     private static Options getOptions() {

--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/cli/VersionSubcommand.java
@@ -28,11 +28,14 @@ public class VersionSubcommand implements Subcommand {
         commandLine = Subcommands.getCommandLine(args, options);
     }
 
-    public String getServerVersion() {
+    public String getformattedServerVersion() {
         InfoControllerApi infoApiClient = new InfoControllerApi();
         try {
             AggregateSourceInfo result = infoApiClient.fetchVersionGET();
-            return result.getGenomeNexus().getServer().getVersion();
+            return "Server: " + result.getGenomeNexus().getServer().getVersion() + System.lineSeparator() +
+             "Annotation Sources" + System.lineSeparator() +
+             "    " + "VEP Server: " +result.getVep().getServer().getVersion() + System.lineSeparator() +
+             "    " + "VEP Cache: "  +result.getVep().getCache().getVersion();
         } catch (ApiException e) {
             LOG.error("Exception when calling InfoControllerApi#fetchVersionGET, genome nexus version is unknown", e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -115,12 +115,12 @@
     <dependency>
       <groupId>com.github.genome-nexus.genome-nexus-java-api-client</groupId>
       <artifactId>genomeNexusPublicApiClient</artifactId>
-      <version>59f677151e77710be41ff07ac92969d383287068</version>
+      <version>7cbbeb94fd3ecb1dca2e51e8a8c71e155cacf2bb</version>
     </dependency>
     <dependency>
       <groupId>com.github.genome-nexus.genome-nexus-java-api-client</groupId>
       <artifactId>genomeNexusInternalApiClient</artifactId>
-      <version>59f677151e77710be41ff07ac92969d383287068</version>
+      <version>7cbbeb94fd3ecb1dca2e51e8a8c71e155cacf2bb</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>


### PR DESCRIPTION
This adds the "Server:" line below to the "version" subcommand, as well as VEP annotation sources:

```
$ java -jar annotationPipeline/target/annotationPipeline-*.jar version
Client: e895367-dirty-SNAPSHOT
Server: 1.0.2
Annotation Sources
    VEP Server: NA
    VEP Cache: NA
    VEP: grch37
    Cancer Hotspots: v2
    HGNC: 22-10-01
    3D Hotspots: v2
    Mutation Assessor: v3
    My Variant Info: Includes many annotation sources, see https://docs.myvariant.info/en/latest/doc/data.html
    reVUE: d8a7d01bac02671e74b4522bacfca6e82f360046
```

Note that current info endpoint does not return the VEP server and cache version, so it currently lists NA, just like the version endpoint: https://www.genomenexus.org/version