### PR TITLE
Revert docker image back to executable form to maintain old usage.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ COPY annotationPipeline/src/main/resources/application.properties.EXAMPLE $GN_HO
 
 RUN apt-get update && apt-get install procps -y
 
-CMD ["java", "-jar", "/genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar"]
+ENTRYPOINT ["java", "-jar", "/genome-nexus-annotation-pipeline/annotationPipeline/target/annotationPipeline.jar"]


### PR DESCRIPTION
We're reverting the Dockerfile back to it's `ENTRYPOINT` executable form to maintain current `docker run` CLI usage.

There is a pending proposal to improve the CLI experience and workflow integration via changes to containerization and the java app itself. For now, we will consider this part of the roadmap.