### PR TITLE
Java11 updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:11.0.20-browsers
+      - image: cimg/openjdk:11.0.20-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/openjdk:8-jdk-browsers
+      - image: circleci/openjdk:11.0.20-browsers
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -656,7 +656,7 @@ public class GenomeNexusImpl implements Annotator {
             AnnotatedRecord annotatedRecord = new AnnotatedRecord(record);
             // if not a failed annotation then convert/merge the response from gn with the maf record
             VariantAnnotation gnResponse = gnResponseVariantKeyMap.get(genomicLocation);
-            if (gnResponse == null) {
+            if (gnResponse == null || !gnResponse.isSuccessfullyAnnotated()) {
                 if(reannotate || annotationNeeded(record)) {
                     // only log if record actually attempted annotation
                     annotatedRecord.setANNOTATION_STATUS("FAILED");

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -656,7 +656,7 @@ public class GenomeNexusImpl implements Annotator {
             AnnotatedRecord annotatedRecord = new AnnotatedRecord(record);
             // if not a failed annotation then convert/merge the response from gn with the maf record
             VariantAnnotation gnResponse = gnResponseVariantKeyMap.get(genomicLocation);
-            if (!gnResponse.isSuccessfullyAnnotated()) {
+            if (gnResponse == null) {
                 if(reannotate || annotationNeeded(record)) {
                     // only log if record actually attempted annotation
                     annotatedRecord.setANNOTATION_STATUS("FAILED");

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,7 @@
+jdk:
+  - openjdk11
+before_install:
+  - sdk install java 11.0.20-tem
+  - sdk use java 11.0.20-tem
+  - sdk install maven
+  - mvn -v

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <properties>
-    <java.version>1.8</java.version>
+    <java.version>11</java.version>
     <slf4j.version>1.7.30</slf4j.version>
     <spring.version>5.2.6.RELEASE</spring.version>
     <jackson.version>2.11.2</jackson.version>
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.github.cbioportal.cbioportal</groupId>
       <artifactId>maf</artifactId>
-      <version>0b2dfa674e</version>
+      <version>a9757e287527b167ef9569ac8f05fcb60cbf3665</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <dependency>
       <groupId>com.github.cbioportal.cbioportal</groupId>
       <artifactId>maf</artifactId>
-      <version>a9757e287527b167ef9569ac8f05fcb60cbf3665</version>
+      <version>ee5802d836c05ed846d7d1ea3f584febdc07ffa8</version>
       <exclusions>
         <exclusion>
           <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This PR contains:

- Updates to build with Java 11
- Check if `gnResponse` is null in `GenomeNexusImpl.java getAnnotatedRecordsUsingPOST()` function to maintain compatibility with CVR fetcher code. Without this change, we saw the following error when running the CVR fetcher:

```
2023-10-02 16:00:39 [main] ERROR org.cbioportal.cmo.pipelines.cvr.mutation.GMLMutationDataReader - Error annotating with POSTs
java.lang.NullPointerException
        at org.cbioportal.annotator.internal.GenomeNexusImpl.getAnnotatedRecordsUsingPOST(GenomeNexusImpl.java:659)
```