### PR TITLE
Return non-zero exit code when annotation pipeline fails

### DIFF
--- a/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
+++ b/annotationPipeline/src/main/java/org/cbioportal/annotation/AnnotationPipeline.java
@@ -131,6 +131,7 @@ public class AnnotationPipeline {
             subMain(args);
         } catch (Exception e) {
             LOG.error(e.getMessage());
+            System.exit(1); // Return non-zero exit code so caller can determine if there was an exception thrown
         }
     }
 


### PR DESCRIPTION
This PR adds a reliable way of checking whether or not the Genome Nexus pipeline failed from the command line. It is needed for the NCI work because we want to distinguish the cases where it is an annotation issue (eg. missing variants) or with the GN code itself.

/cc @averyniceday @leexgh @inodb 