### PR TITLE
Add mutation assessor v4 columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,11 @@ docker run -e GENOMENEXUS_BASE=https://grch38.genomenexus.org -v ${PWD}:/wd geno
 |gnomAD_NFE_AF|myvariant.info|Need to add "my_variant_info" in "genomenexus.enrichment_fields"|
 |gnomAD_OTH_AF|myvariant.info|Need to add "my_variant_info" in "genomenexus.enrichment_fields"|
 |gnomAD_SAS_AF|myvariant.info|Need to add "my_variant_info" in "genomenexus.enrichment_fields"|
-|MA:FIS|Mutation Assessor|Need to add "mutation_assessor" in "genomenexus.enrichment_fields"|
-|MA:FImpact|Mutation Assessor|Need to add "mutation_assessor" in genomenexus.enrichment_fields"|
-|MA:link.MSA|Mutation Assessor|Need to add "mutation_assessor" in "genomenexus.enrichment_fields"|
-|MA:link.PDB|Mutation Assessor|Need to add "mutation_assessor" in "genomenexus.enrichment_fields"|
+|MutationAssessor_FunctionalImpactPrediction|Mutation Assessor|Need to add "mutation_assessor" in "genomenexus.enrichment_fields"|
+|MutationAssessor_FunctionalImpactScore|Mutation Assessor|Need to add "mutation_assessor" in genomenexus.enrichment_fields"|
+|MutationAssessor_MSA|Mutation Assessor|Need to add "mutation_assessor" in genomenexus.enrichment_fields"|
+|MutationAssessor_MAV|Mutation Assessor|Need to add "mutation_assessor" in genomenexus.enrichment_fields"|
+|MutationAssessor_SV|Mutation Assessor|Need to add "mutation_assessor" in genomenexus.enrichment_fields"|
 |Polyphen_Prediction|Polyphen|Need to add "polyphen" in "genomenexus.enrichment_fields"|
 |Polyphen_Score|Polyphen|Need to add "polyphen" in "genomenexus.enrichment_fields"|
 |SIFT_Prediction|SIFT|Need to add "sift" in "genomenexus.enrichment_fields"|
@@ -186,7 +187,7 @@ java -Dgenomenexus.enrichment_fields=annotation_summary,my_variant_info \
 - polyphen
 - sift
 - mutation_assessor
-    - 'mutation_assessor' provides V3 version annotation from Mutation Assessor, which is currently stored in Genome Nexus database
+    - 'mutation_assessor' provides V4 version annotation from Mutation Assessor, which is currently stored in Genome Nexus database
 - nucleotide_context
 - oncokb:
     - 'oncokb' provides annotations of the biological consequences and clinical implications from OncoKB website. OncoKB token is required (see more information from: [https://www.oncokb.org/apiAccess](https://www.oncokb.org/apiAccess)). Please also provide your token in `-Doncokb.token=abc123` command line parameter, or directly add `oncokb.token=abc123`in the `application.properties`. No OncoKB annotation columns will be added if no valid token is provided

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -446,8 +446,9 @@ public class GenomeNexusImpl implements Annotator {
             annotatedRecord.setMutationAssessorFields(
                     annotationUtil.resolveMaFunctionalImpact(gnResponse),
                     annotationUtil.resolveMaFunctionalImpactScore(gnResponse),
-                    annotationUtil.resolveMaLinkMSA(gnResponse),
-                    annotationUtil.resolveMaLinkPDB(gnResponse));
+                    annotationUtil.resolveMaMSA(gnResponse),
+                    annotationUtil.resolveMaMAV(gnResponse),
+                    annotationUtil.resolveMaSV(gnResponse));
         }
         if (enrichmentFields.contains("nucleotide_context")) {
             annotatedRecord.setNucleotideContextFields(

--- a/annotator/src/main/java/org/cbioportal/annotator/util/AnnotationUtil.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/util/AnnotationUtil.java
@@ -32,14 +32,18 @@
 
 package org.cbioportal.annotator.util;
 
-import org.mskcc.cbio.maf.MafUtil;
-import org.cbioportal.models.MutationRecord;
-import org.springframework.stereotype.Component;
-import org.genome_nexus.client.*;
-
-import com.google.common.base.Strings;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.cbioportal.models.MutationRecord;
+import org.genome_nexus.client.AlleleFrequency;
+import org.genome_nexus.client.ColocatedVariant;
+import org.genome_nexus.client.TranscriptConsequenceSummary;
+import org.genome_nexus.client.VariantAnnotation;
+import org.mskcc.cbio.maf.MafUtil;
+import org.springframework.stereotype.Component;
+
+import com.google.common.base.Strings;
 
 /**
  * Utility class for resolving values from the Genome Nexus annotation JSON.
@@ -394,34 +398,42 @@ public class AnnotationUtil {
     
     public String resolveMaFunctionalImpact(VariantAnnotation gnResponse) {
         String maFunctionalImpact = "";
-        if (gnResponse.getMutationAssessor() != null && gnResponse.getMutationAssessor().getAnnotation() != null) {
-            maFunctionalImpact = gnResponse.getMutationAssessor().getAnnotation().getFunctionalImpact();
+        if (gnResponse.getMutationAssessor() != null) {
+            maFunctionalImpact = gnResponse.getMutationAssessor().getFunctionalImpactPrediction();
         }
         return maFunctionalImpact != null ? maFunctionalImpact : "";
     }
 
     public String resolveMaFunctionalImpactScore(VariantAnnotation gnResponse) {
-        Double toReturn = null;
-        if (gnResponse.getMutationAssessor() != null && gnResponse.getMutationAssessor().getAnnotation() != null) {
-            toReturn = gnResponse.getMutationAssessor().getAnnotation().getFunctionalImpactScore();
+        Double maFunctionalImpactScore = null;
+        if (gnResponse.getMutationAssessor() != null) {
+            maFunctionalImpactScore = gnResponse.getMutationAssessor().getFunctionalImpactScore();
         }
-        return parseDoubleAsString(toReturn);
+        return parseDoubleAsString(maFunctionalImpactScore);
     }
 
-    public String resolveMaLinkMSA(VariantAnnotation gnResponse) {
-        String maLinkMSA = "";
-        if (gnResponse.getMutationAssessor() != null && gnResponse.getMutationAssessor().getAnnotation() != null) {
-            maLinkMSA = gnResponse.getMutationAssessor().getAnnotation().getMsaLink();
+    public String resolveMaMSA(VariantAnnotation gnResponse) {
+        String maMSA = "";
+        if (gnResponse.getMutationAssessor() != null) {
+            maMSA = gnResponse.getMutationAssessor().getMsa();
         }
-        return maLinkMSA != null ? maLinkMSA : "";
+        return maMSA;
     }
 
-    public String resolveMaLinkPDB(VariantAnnotation gnResponse) {
-        String maLinkPDB = "";
-        if (gnResponse.getMutationAssessor() != null && gnResponse.getMutationAssessor().getAnnotation() != null) {
-            maLinkPDB = gnResponse.getMutationAssessor().getAnnotation().getPdbLink();
+    public String resolveMaMAV(VariantAnnotation gnResponse) {
+        Integer maMAV = null;
+        if (gnResponse.getMutationAssessor() != null) {
+            maMAV = gnResponse.getMutationAssessor().getMav();
         }
-        return maLinkPDB != null ? maLinkPDB : "";
+        return parseIntegerAsString(maMAV);
+    }
+
+    public String resolveMaSV(VariantAnnotation gnResponse) {
+        Integer maSV = null;
+        if (gnResponse.getMutationAssessor() != null) {
+            maSV = gnResponse.getMutationAssessor().getSv();
+        }
+        return parseIntegerAsString(maSV);
     }
 
     public String resolveRefTri(VariantAnnotation gnResponse) {

--- a/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
+++ b/annotator/src/main/java/org/cbioportal/models/AnnotatedRecord.java
@@ -298,14 +298,13 @@ public class AnnotatedRecord extends MutationRecord {
         addAdditionalProperty("SIFT_Score", siftScore);
     }
     
-    public void setMutationAssessorFields(String maFunctionalImpact,
-            String maFunctionalImpactScore,
-            String maLinkMSA,
-            String maLinkPDB) {
-        addAdditionalProperty("MA:FImpact", maFunctionalImpact);
-        addAdditionalProperty("MA:FIS", maFunctionalImpactScore);
-        addAdditionalProperty("MA:link.MSA", maLinkMSA);
-        addAdditionalProperty("MA:link.PDB", maLinkPDB);
+    public void setMutationAssessorFields(String maFunctionalImpactPrediction,
+            String maFunctionalImpactScore, String maMSA, String maMAV, String maSV) {
+        addAdditionalProperty("MutationAssessor_FunctionalImpactPrediction", maFunctionalImpactPrediction);
+        addAdditionalProperty("MutationAssessor_FunctionalImpactScore", maFunctionalImpactScore);
+        addAdditionalProperty("MutationAssessor_MSA", maMSA);
+        addAdditionalProperty("MutationAssessor_MAV", maMAV);
+        addAdditionalProperty("MutationAssessor_SV", maSV);
     }
 
     public void setNucleotideContextFields(String refTri, String varTri) {

--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,12 @@
     <dependency>
       <groupId>com.github.genome-nexus.genome-nexus-java-api-client</groupId>
       <artifactId>genomeNexusPublicApiClient</artifactId>
-      <version>7128635f2704eb9ebe9c3062770f748ab4127003</version>
+      <version>c8ba14d555</version>
     </dependency>
     <dependency>
       <groupId>com.github.genome-nexus.genome-nexus-java-api-client</groupId>
       <artifactId>genomeNexusInternalApiClient</artifactId>
-      <version>7128635f2704eb9ebe9c3062770f748ab4127003</version>
+      <version>c8ba14d555</version>
     </dependency>
     <dependency>
       <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
Part of: https://github.com/genome-nexus/genome-nexus/issues/753
Removed columns that are not available in new version, add three new columns: `MSA`, `MAV`, `SV`
Example values:
<img width="830" alt="image" src="https://github.com/user-attachments/assets/334ba8c9-7465-4861-b244-2e77ea7cc6ad">
