### PR TITLE
Update document to use mskcc as the default isoform override

### DIFF
--- a/CMD_HELP.md
+++ b/CMD_HELP.md
@@ -18,7 +18,7 @@ annotate subcommand options:
  -e,--error-report-location <arg>   Error report filename (including path)
  -f,--filename <arg>                Mutation filename
  -h,--help                          shows this help document and quits.
- -i,--isoform-override <arg>        Isoform Overrides (mskcc or uniprot)
+ -i,--isoform-override <arg>        Isoform Overrides. Options: `mskcc` (preferred) or uniprot (legacy)
  -o,--output-filename <arg>         Output filename (including path)
  -p,--post-interval-size <arg>      Number of records to make POST requests to Genome Nexus with at
                                     a time
@@ -77,14 +77,14 @@ java -jar gnap.jar annotate --filename in.txt --output-filename out.txt
 After the above command is completed successfully, a file named out.txt, which includes all variants annotated successfully and unsuccessfully will be created.
 
 * **-i, --isoform-override**:
-  * **mskcc** for [Memorial Sloan Kettering Cancer Center](https://www.mskcc.org/) isoforms
-  * **uniprot** for [UniProt](https://www.uniprot.org/) isoforms
+  * **mskcc** for [Memorial Sloan Kettering Cancer Center](https://www.mskcc.org/) isoforms (preferred)
+  * **uniprot** (legacy)
 
 ```
-java -jar gnap.jar annotate --filename in.txt --output-filename out.txt --isoform-override uniprot
+java -jar gnap.jar annotate --filename in.txt --output-filename out.txt --isoform-override mskcc
 ```
 
-After the above command is completed successfully, a file named out.txt, which includes all variants annotated successfully and unsuccessfully overridden by uniprot isoform, will be created.
+After the above command is completed successfully, a file named out.txt, which includes all variants annotated successfully and unsuccessfully overridden by mskcc isoform, will be created.
 
 * **-o, --output-filename**: filename to which annotations will be written.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ java -jar annotationPipeline/target/annotationPipeline-*.jar \
 
 To output error reporting to a file, supply the `-e` option a location for the file to be saved. By running the jar without any arguments or by providing the optional parameter `-h` you can view the full usage statement. 
 
+> [!TIP]
+> `mskcc` is the preferred isoform override, while `uniprot` is a legacy option 
+
 ## Annotate with Docker
 Genome Nexus Annotation Pipeline is available on DockerHub: https://hub.docker.com/r/genomenexus/gn-annotation-pipeline.
 
@@ -62,12 +65,12 @@ docker run -v ${PWD}:/wd genomenexus/gn-annotation-pipeline:master java -jar ann
 | `-f` | `--filename` |Mutation filename|
 | `-o` | `--output-filename` | Output filename (including path)|
 | `-t` | `--output-format`  | extended, minimal or a file path which includes output format (FORMAT EXAMPLE: Chromosome,Hugo_Symbol,Entrez_Gene_Id,Center,NCBI_Build)|
-| `-i` | `--isoform-override` | Isoform Overrides. Options: mskcc or uniprot|
+| `-i` | `--isoform-override` | Isoform Overrides. Options: mskcc (preferred) or uniprot (legacy)|
 | `-e` | `--error-report-location` | Error report filename (including path)|
 | `-r` | `--replace-symbol-entrez` | Replace gene symbols and entrez id with what is provided by annotator, this is enabled by default|
 | `-p` | `--post-interval-size` | Number of records to make POST requests to Genome Nexus with at a time |
 | `-s` | `--strip-matching-bases` | Strip matching allele bases. Options: first, all, none. For example: AAC/AAT, strip-off first: AC/AT, strip-off all: C/T, strip-off none: AAC/AAT  |
-| `-a` | `--add-original-genomic-location` | Add original genomic location data columns into the output, name columns with prefix 'IGNORE_Genome_Nexus_Original_'). This would be useful if saving a reference of original input is needed and won't be changed in any condition|
+| `-a` | `--add-original-genomic-location` | Add original genomic location data columns into the output, name columns with prefix 'IGNORE_Genome_Nexus_Original_'. This would be useful if saving a reference of original input is needed and won't be changed in any condition|
 | `-d` | `--ignore-original-location` | Genome-nexus-annotation-pipeline reads original genomic location info as input by default, if not existing, reading from normal genomic location info columns. Adding `-d` ignores original genomic location info columns (columns with prefix 'IGNORE_Genome_Nexus_Original_') and only use whatever in normal genomic location info columns. This would be helpful if you'd like to stick with current genomic location info columns.|
 
 ### Reference Genome
@@ -82,7 +85,7 @@ The Genome Nexus Annotation Pipeline supports two versions of the human genome r
 If you want to annotate with **GRCh38**, please set the `GENOMENEXUS_BASE` environment variable to `https://grch38.genomenexus.org`. Here's an example of how to do this:
 
 ```
-docker run -e GENOMENEXUS_BASE=https://grch38.genomenexus.org -v ${PWD}:/wd genomenexus/gn-annotation-pipeline:master --filename /wd/input.txt --output-filename /wd/output.txt --isoform-override uniprot
+docker run -e GENOMENEXUS_BASE=https://grch38.genomenexus.org -v ${PWD}:/wd genomenexus/gn-annotation-pipeline:master --filename /wd/input.txt --output-filename /wd/output.txt --isoform-override mskcc
 ```
 
 ### Annotation fields
@@ -176,8 +179,8 @@ java -Dgenomenexus.enrichment_fields=annotation_summary,my_variant_info \
     -jar annotationPipeline/target/annotationPipeline-*.jar \ 
     -r \ 
     --filename test/data/minimal_example.in.txt \ 
-    --output-filename test/data/minimal_example.out.uniprot.txt \ 
-    --isoform-override uniprot
+    --output-filename test/data/minimal_example.out.mskcc.txt \ 
+    --isoform-override mskcc
 ```
 ##### Available enrichment fields:
 - annotation_summary:
@@ -197,14 +200,14 @@ java -Dgenomenexus.enrichment_fields=annotation_summary,my_variant_info \
 For an example minimal input file see
 [test/data/minimal_example.in.txt](test/data/minimal_example.in.txt) and
 corresponding output
-[test/data/minimal_example.out.uniprot.txt](test/data/minimal_example.out.uniprot.txt).
+[test/data/minimal_example.out.mskcc.txt](test/data/minimal_example.out.mskcc.txt).
 The output file was generated with:
 ```
 $JAVA_HOME/bin/java -jar annotationPipeline/target/annotationPipeline-*.jar \
     -r \
     --filename test/data/minimal_example.in.txt  \
-    --output-filename test/data/minimal_example.out.uniprot.txt \
-    --isoform-override uniprot
+    --output-filename test/data/minimal_example.out.mskcc.txt \
+    --isoform-override mskcc
 ```
 
 ## Direct Database Annotation

--- a/test/data/minimal_example.out.mskcc.txt
+++ b/test/data/minimal_example.out.mskcc.txt
@@ -1,5 +1,5 @@
 #genome_nexus_version: 1.0.2
-#isoform: uniprot
+#isoform: mskcc
 Hugo_Symbol	Entrez_Gene_Id	Center	NCBI_Build	Chromosome	Start_Position	End_Position	Strand	Consequence	Variant_Classification	Variant_Type	Reference_Allele	Tumor_Seq_Allele1	Tumor_Seq_Allele2	dbSNP_RS	dbSNP_Val_Status	Tumor_Sample_Barcode	Matched_Norm_Sample_Barcode	Match_Norm_Seq_Allele1	Match_Norm_Seq_Allele2	Tumor_Validation_Allele1	Tumor_Validation_Allele2	Match_Norm_Validation_Allele1	Match_Norm_Validation_Allele2	Verification_Status	Validation_Status	Mutation_Status	Sequencing_Phase	Sequence_Source	Validation_Method	Score	BAM_File	Sequencer	t_ref_count	t_alt_count	n_ref_count	n_alt_count	HGVSc	HGVSp	HGVSp_Short	Transcript_ID	RefSeq	Protein_position	Codons	Exon_Number	genomic_location_explanation	Annotation_Status
 PIK3CA	5290		GRCh37	3	178916927	178916939	+	protein_altering_variant	In_Frame_Del	DEL	TAGGCAACCGTGA	G	G																								ENST00000263967.3:c.314_326delinsG	p.Val105_Glu109delinsGly	p.V105_E109delinsG	ENST00000263967	NM_006218.2	105	gTAGGCAACCGTGAa/gGa	2/21		SUCCESS
 EGFR	1956		GRCh37	7	55220240	55220240	+	splice_region_variant,synonymous_variant	Splice_Region	SNP	G	T	T																								ENST00000275493.2:c.630G>T		p.X210_splice	ENST00000275493	NM_005228.3	210	ctG/ctT	6/28		SUCCESS


### PR DESCRIPTION
Partial fix: https://github.com/genome-nexus/genome-nexus/issues/626
Update document to recommend using mskcc as the isoform override source.