### PR TITLE
Read and process mutation record in batches to reduce memory usage

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
@@ -32,14 +32,17 @@
 
 package org.cbioportal.annotator.internal;
 
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
 import org.cbioportal.annotator.Annotator;
 import org.cbioportal.models.AnnotatedRecord;
 import org.cbioportal.models.MutationRecord;
 import org.mskcc.cbio.maf.MafUtil;
-
-import java.io.*;
-import java.util.*;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/GenomeNexusImpl.java
@@ -705,7 +705,7 @@ public class GenomeNexusImpl implements Annotator {
                     String locationKey = getGenomicLocationString(location);
                     List<Integer> recordIndices = genomicLocationToRecordIndices.get(locationKey);
                     
-                    if (recordIndices != null) {
+                    if (recordIndices != null && !recordIndices.isEmpty() && annotatedRecords.get(recordIndices.getFirst()) == null) {
                         for (Integer index : recordIndices) {
                             MutationRecord record = mutationRecords.get(index);
                             AnnotatedRecord annotatedRecord = new AnnotatedRecord(record);

--- a/annotator/src/test/java/org/cbioportal/annotator/MockGenomeNexusImpl.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/MockGenomeNexusImpl.java
@@ -140,7 +140,7 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
     public AnnotatedRecord makeMockAnnotatedRecord(MutationRecord record) {
         VariantAnnotation gnResponse = null;
         try {
-            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusHgvsResponseMap.get(parseGenomicLocationString(record)));
+            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusHgvsResponseMap.get(parseGenomicLocationString(record, false)));
         }
         catch (IOException e) {
             throw new RuntimeException(e);
@@ -152,7 +152,7 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
     public AnnotatedRecord makeMockPOSTAnnotatedRecord(MutationRecord record) {
         VariantAnnotation gnResponse = null;
         try {
-            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusHgvsPOSTResponseMap.get(parseGenomicLocationString(record)));
+            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusHgvsPOSTResponseMap.get(parseGenomicLocationString(record, false)));
         }
         catch (IOException e) {
             throw new RuntimeException(e);
@@ -164,7 +164,7 @@ public class MockGenomeNexusImpl extends GenomeNexusImpl {
     public AnnotatedRecord makeMockMyVariantInfoAnnotatedRecord(MutationRecord record) {
         VariantAnnotation gnResponse = null;
         try {
-            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusMyVariantInfoResponseMap.get(parseGenomicLocationString(record)));
+            gnResponse = makeMockGenomeNexusResponse(mockGenomeNexusMyVariantInfoResponseMap.get(parseGenomicLocationString(record, false)));
         }
         catch (IOException e) {
             throw new RuntimeException(e);

--- a/annotator/src/test/java/org/cbioportal/annotator/internal/GenomeNexusImplTest.java
+++ b/annotator/src/test/java/org/cbioportal/annotator/internal/GenomeNexusImplTest.java
@@ -32,16 +32,19 @@
 
 package org.cbioportal.annotator.internal;
 
-import org.cbioportal.models.AnnotatedRecord;
-import org.cbioportal.models.MutationRecord;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.cbioportal.annotator.GenomeNexusTestConfiguration;
 import org.cbioportal.annotator.MockGenomeNexusImpl;
-
-import java.util.*;
-import org.junit.*;
+import org.cbioportal.models.AnnotatedRecord;
+import org.cbioportal.models.MutationRecord;
+import org.junit.Assert;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -144,7 +147,7 @@ public class GenomeNexusImplTest {
 
         Map<String, String> expectedGenomicLocations = makeMockExpectedGenomicLocations();
         for (AnnotatedRecord record : mockAnnotatedRecords) {
-            String genomicLocation = annotator.parseGenomicLocationString(record);
+            String genomicLocation = annotator.parseGenomicLocationString(record, false);
             if (!genomicLocation.equals(expectedGenomicLocations.get(record.getTUMOR_SAMPLE_BARCODE()))) {
                 errorMessage.append("testConvertToHgvs(), record genomicLocation '")
                         .append(genomicLocation)


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/796
**Problem**
`gnResponseVariantKeyMap` grows with `VariantAnnotation` added for each variant. It consumes a lot of memory when annotating a large file.
**Updates**
1. This pr tries to process and write in smaller batches to avoid high memory usage.
2. Updates for Annotation Summary. Previously, the annotation summary of invalid or failed annotations was a count for unique variants, now it shows the actual variant count, including duplicated variants. For example:
```
Annotation Summary:
        Records with ambiguous SNP and INDEL allele changes:  0

        Failed annotations summary:  5 total failed annotations
                Records with HGVSp null variant classification:  1
                Records that failed due to other unknown reason: 4
```
This makes more sense to me because when annotating a large file, usually people don't know how many variants are unique, including duplicated variants makes it clearer to tell people how many rows have invalid annotations.