### PR TITLE
Update Dockerfile to use maven 3.9.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build
-FROM maven:3.9.10-eclipse-temurin-21 as build
+FROM maven:3.9.9-eclipse-temurin-21 as build
 
 # Build args
 ARG MAVEN_OPTS=-DskipTests 
@@ -16,7 +16,7 @@ WORKDIR $GN_HOME
 RUN cp $GN_RESOURCES/log4j.properties.console.EXAMPLE $GN_RESOURCES/log4j.properties
 
 # Maven build
-RUN mvn ${MAVEN_OPTS} clean install -DreuseRepositoryLayout=false -q
+RUN mvn ${MAVEN_OPTS} clean install -q
 
 # Stage-1
 FROM eclipse-temurin:21

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build
-FROM maven:3-eclipse-temurin-21 as build
+FROM maven:3.9.8-eclipse-temurin-21 as build
 
 # Build args
 ARG MAVEN_OPTS=-DskipTests 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build
-FROM maven:3.9.8-eclipse-temurin-21 as build
+FROM maven:3.9.9-eclipse-temurin-21 as build
 
 # Build args
 ARG MAVEN_OPTS=-DskipTests 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Multi-stage build
-FROM maven:3.9.9-eclipse-temurin-21 as build
+FROM maven:3.9.10-eclipse-temurin-21 as build
 
 # Build args
 ARG MAVEN_OPTS=-DskipTests 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ WORKDIR $GN_HOME
 RUN cp $GN_RESOURCES/log4j.properties.console.EXAMPLE $GN_RESOURCES/log4j.properties
 
 # Maven build
-RUN mvn ${MAVEN_OPTS} clean install -q
+RUN mvn ${MAVEN_OPTS} clean install -DreuseRepositoryLayout=false -q
 
 # Stage-1
 FROM eclipse-temurin:21


### PR DESCRIPTION
Fix: https://github.com/genome-nexus/genome-nexus/issues/800
Since mvn [3.9.10](https://maven.apache.org/docs/3.9.10/release-notes.html), it updates the Resolver engine version. Maybe concurrent builds are changed or verification logic is changed. Dynamic versioning is misaligned for parent and child since this version. However 3.9.9 works (from 2 months ago), switching to use the static version of mvn 3.9.9 